### PR TITLE
Enhance sonarr radarr connector

### DIFF
--- a/src/scraparr/connectors/radarr.py
+++ b/src/scraparr/connectors/radarr.py
@@ -5,6 +5,7 @@ Module to handle the Metrics of the Radarr Service
 import time
 from datetime import datetime
 import scraparr.metrics.radarr as radarr_metrics
+from scraparr.metrics.general import UP
 from scraparr.util import get
 
 def get_movies(url, api_key):
@@ -14,7 +15,10 @@ def get_movies(url, api_key):
     res = get(f"{url}/api/v3/movie", api_key)
     end_time = time.time()
 
-    if not res == {}:
+    if res == {}:
+        UP.labels("radarr").set(0)
+    else:
+        UP.labels("radarr").set(1)
         radarr_metrics.LAST_SCRAPE.set(end_time)
         radarr_metrics.SCRAPE_DURATION.set(end_time - initial_time)
     return res

--- a/src/scraparr/connectors/sonarr.py
+++ b/src/scraparr/connectors/sonarr.py
@@ -22,66 +22,64 @@ def get_series(url, api_key):
         sonarr_metrics.LAST_SCRAPE.set(end_time)
         sonarr_metrics.SCRAPE_DURATION.set(end_time - initial_time)
     return res
-
 def analyse_series(series, detailed):
     """Analyse the Series and set the Correct Metrics"""
+
     sonarr_metrics.SERIES_COUNT.labels("total").set(len(series))
+
+    status_labels = {
+        "continuing": sonarr_metrics.CONTINUING_SERIES,
+        "upcoming": sonarr_metrics.UPCOMING_SERIES,
+        "ended": sonarr_metrics.ENDED_SERIES,
+        "deleted": sonarr_metrics.DELETED_SERIES
+    }
 
     for serie in series:
         title = serie["titleSlug"]
 
-        episode_count = serie["statistics"]["episodeCount"]
-        episode_file_count = serie["statistics"]["episodeFileCount"]
-        size_on_disk = serie["statistics"]["sizeOnDisk"]
-        season_count = serie["statistics"]["seasonCount"]
-        percent_of_episodes = serie["statistics"]["percentOfEpisodes"]
+
+        stats = serie["statistics"]
+        episode_count = stats["episodeCount"]
+        episode_file_count = stats["episodeFileCount"]
+        size_on_disk = stats["sizeOnDisk"]
 
         sonarr_metrics.SERIES_COUNT.labels(serie["rootFolderPath"]).inc()
-
         sonarr_metrics.EPISODE_COUNT.labels("total").inc(episode_count)
         sonarr_metrics.EPISODE_COUNT.labels(serie["rootFolderPath"]).inc()
 
-        for season in serie["seasons"]:
-            if season['monitored']:
-                missing = episode_count - episode_file_count
-                sonarr_metrics.MISSING_EPISODE_COUNT.labels("total").inc(missing)
-                sonarr_metrics.MISSING_EPISODE_COUNT.labels(serie["rootFolderPath"]).inc(missing)
-                if detailed:
-                    sonarr_metrics.SERIES_MISSING_EPISODE_COUNT.labels(title).set(missing)
-
+        monitored_seasons = any(season['monitored'] for season in serie["seasons"])
+        if monitored_seasons:
+            missing = episode_count - episode_file_count
+            sonarr_metrics.MISSING_EPISODE_COUNT.labels("total").inc(missing)
+            sonarr_metrics.MISSING_EPISODE_COUNT.labels(serie["rootFolderPath"]).inc(missing)
+            if detailed:
+                sonarr_metrics.SERIES_MISSING_EPISODE_COUNT.labels(title).set(missing)
 
         sonarr_metrics.TOTAL_DISK_SIZE.labels("total").inc(size_on_disk)
         sonarr_metrics.TOTAL_DISK_SIZE.labels(serie["rootFolderPath"]).inc(size_on_disk)
+
         if detailed:
             sonarr_metrics.SERIES_EPISODE_COUNT.labels(title).set(episode_count)
-            sonarr_metrics.SERIES_SEASON_COUNT.labels(title).set(season_count)
+            sonarr_metrics.SERIES_SEASON_COUNT.labels(title).set(stats["seasonCount"])
             sonarr_metrics.SERIES_DISK_SIZE.labels(title).set(size_on_disk)
-            sonarr_metrics.SERIES_DOWNLOAD_PERCENTAGE.labels(title).set(percent_of_episodes)
+            sonarr_metrics.SERIES_DOWNLOAD_PERCENTAGE.labels(title).set(stats["percentOfEpisodes"])
             sonarr_metrics.SERIES_MONITORED.labels(title).set(1 if serie["monitored"] else 0)
 
-        if serie["status"] == "continuing":
-            sonarr_metrics.CONTINUING_SERIES.labels("total").inc()
-            sonarr_metrics.CONTINUING_SERIES.labels(serie["rootFolderPath"]).inc()
-        elif serie["status"] == "upcoming":
-            sonarr_metrics.UPCOMING_SERIES.labels("total").inc()
-            sonarr_metrics.UPCOMING_SERIES.labels(serie["rootFolderPath"]).inc()
-        elif serie["status"] == "ended":
-            sonarr_metrics.ENDED_SERIES.labels("total").inc()
-            sonarr_metrics.ENDED_SERIES.labels(serie["rootFolderPath"]).inc()
-        elif serie["status"] == "deleted":
-            sonarr_metrics.DELETED_SERIES.labels("total").inc()
-            sonarr_metrics.DELETED_SERIES.labels(serie["rootFolderPath"]).inc()
+        # Status mit Dictionary verarbeiten
+        if serie["status"] in status_labels:
+            status_labels[serie["status"]].labels("total").inc()
+            status_labels[serie["status"]].labels(serie["rootFolderPath"]).inc()
 
         for genre in serie["genres"]:
             sonarr_metrics.SERIES_GENRES_COUNT.labels(genre, "total").inc()
             sonarr_metrics.SERIES_GENRES_COUNT.labels(genre, serie["rootFolderPath"]).inc()
 
         if serie["monitored"]:
-            sonarr_metrics.MONITORED_SERIES.labels("total").inc()
-            sonarr_metrics.MONITORED_SERIES.labels(serie["rootFolderPath"]).inc()
+            monitored_label = sonarr_metrics.MONITORED_SERIES
         else:
-            sonarr_metrics.UNMONITORED_SERIES.labels("total").inc()
-            sonarr_metrics.UNMONITORED_SERIES.labels(serie["rootFolderPath"]).inc()
+            monitored_label = sonarr_metrics.UNMONITORED_SERIES
+        monitored_label.labels("total").inc()
+        monitored_label.labels(serie["rootFolderPath"]).inc()
 
 def update_system_data(data):
     """Update the System Data Metrics"""

--- a/src/scraparr/connectors/sonarr.py
+++ b/src/scraparr/connectors/sonarr.py
@@ -18,6 +18,10 @@ def get_series(url, api_key):
     if res == {}:
         UP.labels("sonarr").set(0)
     else:
+        for series in res:
+            episodes = get(f"{url}/api/v3/episodefile?seriesId={series['id']}", api_key)
+            series["episodes"] = episodes
+
         UP.labels("sonarr").set(1)
         sonarr_metrics.LAST_SCRAPE.set(end_time)
         sonarr_metrics.SCRAPE_DURATION.set(end_time - initial_time)
@@ -37,6 +41,10 @@ def analyse_series(series, detailed):
     for serie in series:
         title = serie["titleSlug"]
 
+        for episode in serie["episodes"]:
+            quality = episode['quality']['quality']['name']
+            sonarr_metrics.QUALITY_EPISODE_COUNT.labels(quality, "total").inc()
+            sonarr_metrics.QUALITY_EPISODE_COUNT.labels(quality, serie["rootFolderPath"]).inc()
 
         stats = serie["statistics"]
         episode_count = stats["episodeCount"]

--- a/src/scraparr/connectors/sonarr.py
+++ b/src/scraparr/connectors/sonarr.py
@@ -5,6 +5,7 @@ Module to handle the Metrics of the Sonarr Service
 import time
 from datetime import datetime
 from scraparr.util import get
+from scraparr.metrics.general import UP
 import scraparr.metrics.sonarr as sonarr_metrics
 
 def get_series(url, api_key):
@@ -14,7 +15,10 @@ def get_series(url, api_key):
     res = get(f"{url}/api/v3/series", api_key)
     end_time = time.time()
 
-    if not res == {}:
+    if res == {}:
+        UP.labels("sonarr").set(0)
+    else:
+        UP.labels("sonarr").set(1)
         sonarr_metrics.LAST_SCRAPE.set(end_time)
         sonarr_metrics.SCRAPE_DURATION.set(end_time - initial_time)
     return res

--- a/src/scraparr/metrics/general.py
+++ b/src/scraparr/metrics/general.py
@@ -1,0 +1,4 @@
+"""Module for General Metrics"""
+from prometheus_client import Gauge
+
+UP = Gauge('up', 'If the scrape of the Service was successful', ['service'])

--- a/src/scraparr/metrics/radarr.py
+++ b/src/scraparr/metrics/radarr.py
@@ -19,6 +19,7 @@ TOTAL_DISK_SIZE = Gauge('radarr_total_disk_size', 'Total disk size of movies in 
 FREE_DISK_SIZE = Gauge('radarr_free_disk_size', 'Free disk size in Radarr', ['path'])
 AVAILABLE_DISK_SIZE = Gauge('radarr_available_disk_size', 'Available disk size in Radarr', ['path'])
 MISSING_MOVIES_COUNT = Gauge('radarr_missing_movies', 'Number of missing movies in Radarr', ['path'])
+QUALITY_MOVIE_COUNT = Gauge('radarr_quality_movies', 'Number of movies per quality in Radarr', ['quality', 'path'])
 
 MOVIE_GENRES_COUNT = Gauge('radarr_genres_count', 'Number of Movies per Genres in Radarr', ['genre', 'path'])
 

--- a/src/scraparr/metrics/sonarr.py
+++ b/src/scraparr/metrics/sonarr.py
@@ -20,6 +20,7 @@ TOTAL_DISK_SIZE = Gauge('sonarr_total_disk_size', 'Total disk size of Series in 
 FREE_DISK_SIZE = Gauge('sonarr_free_disk_size', 'Free disk size in Sonarr', ['path'])
 AVAILABLE_DISK_SIZE = Gauge('sonarr_available_disk_size', 'Available disk size in Sonarr', ['path'])
 MISSING_EPISODE_COUNT = Gauge('sonarr_missing_episodes', 'Number of missing episodes in Sonarr', ['path'])
+QUALITY_EPISODE_COUNT = Gauge('sonarr_quality_episodes', 'Number of episodes per quality in Sonarr', ['quality', 'path'])
 
 SERIES_GENRES_COUNT = Gauge('sonarr_genres_count', 'Number of Series per Genres in Sonarr', ['genre', 'path'])
 


### PR DESCRIPTION
This pull request includes several changes to the `scraparr` project, focusing on improving the metrics collection for Radarr and Sonarr services. The changes include adding new metrics, refactoring existing code to use dictionaries for status processing, and updating the `get_movies` and `get_series` functions to handle empty responses more effectively.

### Metrics Improvements:
* Added a new `UP` metric in `src/scraparr/metrics/general.py` to indicate if the scrape of the service was successful.
* Introduced `QUALITY_MOVIE_COUNT` and `QUALITY_EPISODE_COUNT` metrics in `src/scraparr/metrics/radarr.py` and `src/scraparr/metrics/sonarr.py`, respectively, to track the number of movies and episodes per quality. [[1]](diffhunk://#diff-a7177cba7ae19cf9febdecf193942e01d3195adb08cee4eef6f7e3dd55d1b13cR22) [[2]](diffhunk://#diff-1be61bce5585976ce8aa33baf46f999e977a623da99f5045b8e62d9fe8ab179fR23)

### Code Refactoring:
* Refactored the `analyse_movies` and `analyse_series` functions to use dictionaries for status processing, simplifying the code and reducing redundancy. [[1]](diffhunk://#diff-9e2f76806cce2591d3bc0233ca82f9d17d2a73922f173abed9eac0e207908503L45-R77) [[2]](diffhunk://#diff-f01b48335ab94f4725ad36a5eddc5e26fe659b356233fa758813b2de31a9cc6cL17-R90)
* Updated the `get_movies` and `get_series` functions to handle empty responses by setting the `UP` metric to 0 when the response is empty, and to 1 when the response is not empty. [[1]](diffhunk://#diff-9e2f76806cce2591d3bc0233ca82f9d17d2a73922f173abed9eac0e207908503L17-R25) [[2]](diffhunk://#diff-f01b48335ab94f4725ad36a5eddc5e26fe659b356233fa758813b2de31a9cc6cL17-R90)

### Additional Enhancements:
* Enhanced the `analyse_movies` and `analyse_series` functions to include quality metrics for movie files and episodes, respectively. [[1]](diffhunk://#diff-9e2f76806cce2591d3bc0233ca82f9d17d2a73922f173abed9eac0e207908503R35-L36) [[2]](diffhunk://#diff-f01b48335ab94f4725ad36a5eddc5e26fe659b356233fa758813b2de31a9cc6cL17-R90)