### PR TITLE
Add Basic Auth and Bearer Authentication to Metrics Endpoint

### DIFF
--- a/config.cnf
+++ b/config.cnf
@@ -5,6 +5,13 @@
 ; Exporter Metrics Path
 ;path = /metrics
 
+[AUTH]
+; Basic Auth
+;username = user
+;password = pass
+; Bearer Token
+;token = token
+
 [SONARR]
 url = http://sonarr:8989
 api_key = key

--- a/src/scraparr/middleware.py
+++ b/src/scraparr/middleware.py
@@ -2,23 +2,51 @@
 This is the Middleware module for the WSGI application.
 """
 
+import base64
 from werkzeug.wrappers import Request
 
 class Middleware:
-    """WSGI Middleware to only allow /metrics path"""
-    def __init__(self, app):
+    """WSGI Middleware to only allow /metrics path with authentication"""
+    def __init__(self, app, username=None, password=None, api_token=None):
         self.app = app
+        self.username = username
+        self.password = password
+        self.api_token = api_token
 
     def __call__(self, environ, start_response):
         request = Request(environ)
 
-        # Only allow /metrics
+        # Only allow access to /metrics
         if request.path != "/metrics":
             return self.show_html_page(start_response)
 
+        # Check authentication
+        if (self.username and self.password) or self.api_token:
+            if not self.is_authenticated(request):
+                return self.show_unauthorized_response(start_response)
+
         return self.app(environ, start_response)
 
-    def show_html_page(self, start_response):
+    def is_authenticated(self, request):
+        """Checks if the request is authenticated using either Basic Auth or API Token"""
+        # Check for Basic Authentication
+        auth_header = request.headers.get("Authorization")
+        if auth_header and auth_header.startswith("Basic "):
+            encoded_credentials = auth_header.split(" ", 1)[1]
+            decoded_credentials = base64.b64decode(encoded_credentials).decode("utf-8")
+            username, password = decoded_credentials.split(":", 1)
+            if username == self.username and password == self.password:
+                return True
+
+        # Check for API Token in the Authorization header
+        if auth_header and auth_header == f"Bearer {self.api_token}":
+            return True
+
+        # If no valid authentication is found
+        return False
+
+    @staticmethod
+    def show_html_page(start_response):
         """Returns a simple HTML page for non-/metrics paths"""
         html_content = b"""
         <!DOCTYPE html>
@@ -41,3 +69,15 @@ class Middleware:
         """
         start_response("200 OK", [("Content-Type", "text/html")])
         return [html_content]
+
+    @staticmethod
+    def show_unauthorized_response(start_response):
+        """Returns a 401 Unauthorized response"""
+        start_response(
+            "401 Unauthorized",
+            [
+                ("Content-Type", "text/plain"),
+                ("WWW-Authenticate", 'Basic realm="Login Required"')
+            ]
+        )
+        return [b"Unauthorized access. Please provide valid credentials."]

--- a/src/scraparr/scraparr.py
+++ b/src/scraparr/scraparr.py
@@ -23,34 +23,38 @@ import scraparr.connectors
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
-config = configparser.ConfigParser()
-config.read('scraparr/config.cnf')
+CONFIG = configparser.ConfigParser()
+CONFIG.read('scraparr/config.cnf')
 
-path = config.get('GENERAL', 'path', fallback="/metrics")
-address = config.get('GENERAL', 'address', fallback="0.0.0.0")
-port = config.get('GENERAL', 'port', fallback=7100)
+PATH = CONFIG.get('GENERAL', 'path', fallback="/metrics")
+ADDRESS = CONFIG.get('GENERAL', 'address', fallback="0.0.0.0")
+PORT = CONFIG.get('GENERAL', 'port', fallback=7100)
+
+USERNAME = CONFIG.get('AUTH', 'username', fallback=None)
+PASSWORD = CONFIG.get('AUTH', 'password', fallback=None)
+BEARER_TOKEN = CONFIG.get('AUTH', 'token', fallback=None)
 
 metrics_app = make_wsgi_app()
-app = Middleware(metrics_app)
+app = Middleware(metrics_app, USERNAME, PASSWORD, BEARER_TOKEN)
 
 ACTIVE_CONNECTORS = ['SONARR', 'RADARR', 'PROWLARR']
 BEAUTIFUL_CONNECTORS = ", ".join(ACTIVE_CONNECTORS[:-1]) + " or " + ACTIVE_CONNECTORS[-1]
 
 if __name__ == '__main__':
-    if not any(section in config.sections() for section in ACTIVE_CONNECTORS):
+    if not any(section in CONFIG.sections() for section in ACTIVE_CONNECTORS):
         logging.info("No configuration found for %s", BEAUTIFUL_CONNECTORS)
         sys.exit(1)
 
     connectors = scraparr.connectors.Connectors()
 
-    for section in config.sections():
+    for section in CONFIG.sections():
         if section in ACTIVE_CONNECTORS:
-            connectors.add_connector(section.lower(), dict(config.items(section)))
+            connectors.add_connector(section.lower(), dict(CONFIG.items(section)))
 
     try:
         def run_server():
             """Starts the WSGI server"""
-            httpd = make_server(address, port, app)
+            httpd = make_server(ADDRESS, PORT, app)
             httpd.serve_forever()
 
         server_thread = threading.Thread(target=run_server)


### PR DESCRIPTION
This pull request introduces authentication to the `/metrics` path by adding support for Basic Auth and Bearer Token. It also includes some refactoring and configuration changes to support the new authentication feature.

Authentication and Security:

* [`src/scraparr/middleware.py`](diffhunk://#diff-77c80fd87918215dc64c4694a995abe79d51e4b8e743377ea2d78f6ff7168957R5-R49): Modified the `Middleware` class to include authentication checks for Basic Auth and Bearer Token. Added methods `is_authenticated` and `show_unauthorized_response` to handle authentication logic and unauthorized responses. [[1]](diffhunk://#diff-77c80fd87918215dc64c4694a995abe79d51e4b8e743377ea2d78f6ff7168957R5-R49) [[2]](diffhunk://#diff-77c80fd87918215dc64c4694a995abe79d51e4b8e743377ea2d78f6ff7168957R72-R83)

Configuration Updates:

* [`config.cnf`](diffhunk://#diff-fde39f44fb116e4243416efa140a09d7a9e30539698e2d496b4ffb00f15628baR8-R14): Added a new `[AUTH]` section to configure Basic Auth and Bearer Token credentials.
* [`src/scraparr/scraparr.py`](diffhunk://#diff-e62ee6aa3cd382bab2ba7d3af815a0e489ab167fc59a40082517926f7aac956eL26-R57): Updated the configuration parsing to read the new `[AUTH]` section and pass the credentials to the `Middleware` class.