### PR TITLE
Move Config file into config folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can either Clone the Repo and build the Docker Image locally or you can use 
 You can also check the [Docker-Compose](compose.yaml).
 
 Github Registry:
-`docker run -v ./config.cnf:/scraparr/config.cnf -p 7100:7100 ghcr.io/thecfu/scraparr`
+`docker run -v ./config.cnf:/scraparr/config/config.cnf -p 7100:7100 ghcr.io/thecfu/scraparr`
 
 ## Configuration
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,4 +5,4 @@ services:
     ports:
       - "7100:7100"
     volumes:
-      - ./config.cnf:/scraparr/config.cnf
+      - ./config.cnf:/scraparr/config/config.cnf

--- a/src/scraparr/scraparr.py
+++ b/src/scraparr/scraparr.py
@@ -24,7 +24,7 @@ import scraparr.connectors
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
 CONFIG = configparser.ConfigParser()
-CONFIG.read('scraparr/config.cnf')
+CONFIG.read('/scraparr/config/config.cnf')
 
 PATH = CONFIG.get('GENERAL', 'path', fallback="/metrics")
 ADDRESS = CONFIG.get('GENERAL', 'address', fallback="0.0.0.0")


### PR DESCRIPTION
Move the Config File into a new Config folder, to ensure compatibility with 3rd-Party Applications

Configuration updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L41-R41): Updated the Docker run command to use the new configuration file path `/scraparr/config/config.cnf`.
* [`compose.yaml`](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cL8-R8): Updated the volume mount path in the Docker Compose file to `/scraparr/config/config.cnf`.
* [`src/scraparr/scraparr.py`](diffhunk://#diff-e62ee6aa3cd382bab2ba7d3af815a0e489ab167fc59a40082517926f7aac956eL27-R27): Updated the configuration file path in the Python script to `/scraparr/config/config.cnf`.