### PR TITLE
Modify code so the Api_version gets assigned correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,10 @@ Template for Service inside the config.cnf:
 [SONARR]
 url = http://localhost:8989
 api_key = YOUR_KEY
-api_version = v3
-detailed = true
+; (Optional) specify API version
+; api_version = v3
+; (Optional) Get Data per Series
+; detailed = true
 ```
 
 > [!NOTE]  

--- a/config.cnf
+++ b/config.cnf
@@ -15,20 +15,23 @@
 [SONARR]
 url = http://sonarr:8989
 api_key = key
-api_version = v3
-; Get Data per Series
+; (Optional) specify API version
+; api_version = v3
+; (Optional) Get Data per Series
 detailed = true
 
 [RADARR]
 url = http://radarr:7878
 api_key = key
-api_version = v3
-; Get Data per Movie
+; (Optional) specify API version
+; api_version = v3
+; (Optional) Get Data per Movie
 detailed = true
 
 [PROWLARR]
 url = http://prowlarr:9696
 api_key = key
-api_version = v1
-; Get Data per Application/Indexer
+; (Optional) specify API version
+; api_version = v1
+; (Optional) Get Data per Application/Indexer
 detailed = true

--- a/src/scraparr/connectors/radarr.py
+++ b/src/scraparr/connectors/radarr.py
@@ -113,7 +113,7 @@ def scrape(config):
 
     url = config.get('url')
     api_key = config.get('api_key')
-    api_version = config.get('api_version', 'v1')
+    api_version = config.get('api_version', 'v3')
 
     return get_movies(url, api_key, api_version)
 

--- a/src/scraparr/connectors/sonarr.py
+++ b/src/scraparr/connectors/sonarr.py
@@ -126,7 +126,7 @@ def scrape(config):
 
     url = config.get('url')
     api_key = config.get('api_key')
-    api_version = config.get('api_version', 'v1')
+    api_version = config.get('api_version', 'v3')
 
     return get_series(url, api_key, api_version)
 


### PR DESCRIPTION
This pull request includes changes to improve the configuration flexibility and update default API versions for the `scraparr` connectors. The most important changes are the addition of optional comments in configuration files and the update of default API versions in the connector scripts.

Configuration updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L53-R56): Added optional comments for `api_version` and `detailed` settings in the `Template for Service inside the config.cnf` section.
* [`config.cnf`](diffhunk://#diff-fde39f44fb116e4243416efa140a09d7a9e30539698e2d496b4ffb00f15628baL18-R36): Updated to include optional comments for `api_version` and `detailed` settings for `SONARR`, `RADARR`, and `PROWLARR` services.

Connector script updates:

* [`src/scraparr/connectors/radarr.py`](diffhunk://#diff-9e2f76806cce2591d3bc0233ca82f9d17d2a73922f173abed9eac0e207908503L116-R116): Assign correct API-Version as default.
* [`src/scraparr/connectors/sonarr.py`](diffhunk://#diff-f01b48335ab94f4725ad36a5eddc5e26fe659b356233fa758813b2de31a9cc6cL129-R129): Assign correct API-Version as default.

Closes #40