### PR TITLE
Move Config file into separate config folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can either Clone the Repo and build the Docker Image locally or you can use 
 You can also check the [Docker-Compose](compose.yaml).
 
 Github Registry:
-`docker run -v ./config.cnf:/scraparr/config.cnf -p 7100:7100 ghcr.io/thecfu/scraparr`
+`docker run -v ./config.cnf:/scraparr/config/config.cnf -p 7100:7100 ghcr.io/thecfu/scraparr`
 
 ## Configuration
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,4 +5,4 @@ services:
     ports:
       - "7100:7100"
     volumes:
-      - ./config.cnf:/scraparr/config.cnf
+      - ./config.cnf:/scraparr/config/config.cnf

--- a/src/scraparr/scraparr.py
+++ b/src/scraparr/scraparr.py
@@ -14,6 +14,7 @@ import sys
 import threading
 import configparser
 import logging
+from os.path import exists
 
 from wsgiref.simple_server import make_server
 from prometheus_client import make_wsgi_app
@@ -23,8 +24,18 @@ import scraparr.connectors
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
+def get_config_path():
+    """Check if the Config is in new or old location"""
+    config_path = '/scraparr/config/config.cnf'
+    if not exists(config_path):
+        logging.warning("No config found in new location, checking old location")
+        logging.warning("Please move the config to /scraparr/config/config.cnf")
+        config_path = '/scraparr/config.cnf'
+    return config_path
+
 CONFIG = configparser.ConfigParser()
-CONFIG.read('scraparr/config.cnf')
+
+CONFIG.read(get_config_path())
 
 PATH = CONFIG.get('GENERAL', 'path', fallback="/metrics")
 ADDRESS = CONFIG.get('GENERAL', 'address', fallback="0.0.0.0")


### PR DESCRIPTION
This pull request includes changes to ensure the configuration file is read from the correct location and to provide a fallback mechanism if it is not found. Additionally, there are updates to the documentation and Docker configuration to reflect these changes.

### Configuration file handling improvements:
* [`src/scraparr/scraparr.py`](diffhunk://#diff-e62ee6aa3cd382bab2ba7d3af815a0e489ab167fc59a40082517926f7aac956eR27-R38): Added a new function `get_config_path` to check if the configuration file exists in the new location and provide a fallback to the old location if it is not found. Updated the `CONFIG.read` call to use this new function.

### Documentation updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L41-R41): Updated the Docker run command to use the new configuration file path.

### Docker configuration updates:
* [`compose.yaml`](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cL8-R8): Updated the volume mapping to use the new configuration file path.


resolves #41 