### PR TITLE
Switch Datetime to dateutil to have dynamic date format

### DIFF
--- a/src/scraparr/connectors/__init__.py
+++ b/src/scraparr/connectors/__init__.py
@@ -21,16 +21,16 @@ class Connectors:
     def add_connector(self, service, configs):
         """Function to add a Connector on successful load into the List of Connectors"""
         importer = self.load_connector(service)
-        
+
         api_versions = {"sonarr": "v3", "radarr": "v3", "prowlarr": "v1"}
 
         if importer:
             self.connectors[service] = []
             for config in configs:
-                
+
                 if config.get('api_version') is None:
                     config['api_version'] = api_versions[service]
-                
+
                 connector_entry = {
                     "function": importer,
                     "config": config

--- a/src/scraparr/connectors/prowlarr.py
+++ b/src/scraparr/connectors/prowlarr.py
@@ -3,7 +3,7 @@ Module to handle the Metrics of the Prowlarr Service
 """
 
 import time
-from datetime import datetime
+from dateutil.parser import parse
 
 from scraparr.util import get
 from scraparr.metrics.general import UP
@@ -48,8 +48,8 @@ def get_applications(url, api_key, version, alias):
 def update_system_data(data, alias):
     """Update the System Data"""
 
-    start_time = datetime.strptime(data["status"]["startTime"], "%Y-%m-%dT%H:%M:%SZ").timestamp()
-    build_time = datetime.strptime(data["status"]["buildTime"], "%Y-%m-%dT%H:%M:%SZ").timestamp()
+    start_time = parse(data["status"]["startTime"]).timestamp()
+    build_time = parse(data["status"]["buildTime"]).timestamp()
     prowlarr_metrics.START_TIME.labels(alias).set(start_time)
     prowlarr_metrics.BUILD_TIME.labels(alias).set(build_time)
 
@@ -117,7 +117,7 @@ def analyse_indexers(indexers, detailed, alias):
             if field['name'] == 'vipExpiration':
                 vip_expiration = field['value']
                 if vip_expiration:
-                    vip_expiration = datetime.strptime(vip_expiration, "%Y-%m-%d").timestamp()
+                    vip_expiration = parse(vip_expiration).timestamp()
                     prowlarr_metrics.VIP_EXPIRATION.labels(alias, name).set(vip_expiration)
                 break
 

--- a/src/scraparr/requirements.txt
+++ b/src/scraparr/requirements.txt
@@ -1,4 +1,5 @@
 prometheus_client
 requests
 werkzeug
+python-dateutil
 pyyaml


### PR DESCRIPTION
This pull request includes changes to the `src/scraparr/connectors/prowlarr.py` file and updates the `requirements.txt` file. The main focus is on replacing the `datetime` module with the `dateutil.parser` module for parsing date strings and adding the `python-dateutil` dependency.

### Changes to date parsing:

* [`src/scraparr/connectors/prowlarr.py`](diffhunk://#diff-93ce7a7032828bbeb3a7414c7834ee21dc34c971f1bdf4a8127abc60b87735adL51-R52): Replaced `datetime.strptime` with `dateutil.parser.parse` for parsing date strings in the `update_system_data` and `analyse_indexers` functions. [[1]](diffhunk://#diff-93ce7a7032828bbeb3a7414c7834ee21dc34c971f1bdf4a8127abc60b87735adL51-R52) [[2]](diffhunk://#diff-93ce7a7032828bbeb3a7414c7834ee21dc34c971f1bdf4a8127abc60b87735adL120-R120)

### Dependency updates:

* [`src/scraparr/requirements.txt`](diffhunk://#diff-cfe91cdd1700ad48be4b3c81e9c957dcc24069f7f3b051aa5ad942128fe282bdR4): Added the `python-dateutil` dependency to the requirements file.
