### PR TITLE
Include Posibility of Rootfolder only beeing a subpath of a disk

### DIFF
--- a/src/scraparr/connectors/__init__.py
+++ b/src/scraparr/connectors/__init__.py
@@ -83,27 +83,30 @@ class Connectors:
                 report = []
                 seen_paths = set()  # To keep track of added paths
 
-                for rootfoler in folder:
+                for rootfolder in folder:
                     for disk in disks:
-                        if disk["path"] == rootfoler["path"] and disk["path"] not in seen_paths:
+                        if disk["path"] == rootfolder["path"] and disk["path"] not in seen_paths:
                             report.append(disk)
                             seen_paths.add(disk["path"])
                             break
                     else:
                         for disk in disks:
-                            if rootfoler["path"].startswith(disk["path"] and disk["path"] not in seen_paths):
+                            if (
+                                    rootfolder["path"].startswith(disk["path"])
+                                    and disk["path"] not in seen_paths
+                                ):
                                 report.append(disk)
                                 seen_paths.add(disk["path"])
                                 break
                         else:
                             logging.warning("No diskspace data found for %s,"
-                                            " using only available Data", rootfoler["path"])
+                                            " using only available Data", rootfolder["path"])
                             report.append({
-                                "path": rootfoler["path"],
-                                "freeSpace":  rootfoler["freeSpace"],
+                                "path": rootfolder["path"],
+                                "freeSpace":  rootfolder["freeSpace"],
                                 "totalSpace": -1
                             })
-                            seen_paths.add(rootfoler["path"])
+                            seen_paths.add(rootfolder["path"])
                 return report
             data = get(f"{url}/api/{api_version}/rootfolder", api_key)
             if data:

--- a/src/scraparr/connectors/__init__.py
+++ b/src/scraparr/connectors/__init__.py
@@ -85,18 +85,17 @@ class Connectors:
 
                 for rootfolder in folder:
                     for disk in disks:
-                        if disk["path"] == rootfolder["path"] and disk["path"] not in seen_paths:
-                            report.append(disk)
-                            seen_paths.add(disk["path"])
+                        if disk["path"] == rootfolder["path"]:
+                            if not disk["path"] in seen_paths:
+                                report.append(disk)
+                                seen_paths.add(disk["path"])
                             break
                     else:
                         for disk in disks:
-                            if (
-                                    rootfolder["path"].startswith(disk["path"])
-                                    and disk["path"] not in seen_paths
-                                ):
-                                report.append(disk)
-                                seen_paths.add(disk["path"])
+                            if rootfolder["path"].startswith(disk["path"]) and disk["path"] != '/':
+                                if not disk["path"] in seen_paths:
+                                    report.append(disk)
+                                    seen_paths.add(disk["path"])
                                 break
                         else:
                             logging.warning("No diskspace data found for %s,"

--- a/src/scraparr/connectors/__init__.py
+++ b/src/scraparr/connectors/__init__.py
@@ -84,9 +84,25 @@ class Connectors:
                 diskspace_data = get(f"{url}/api/{api_version}/diskspace", api_key)
                 if diskspace_data:
                     report = []
-                    for disk in diskspace_data:
-                        if any(disk["path"] == d["path"] for d in data):
-                            report.append(disk)
+                    seen_paths = set()  # To keep track of added paths
+
+                    for rootfoler in data:
+                        for disk in diskspace_data:
+                            if disk["path"] == rootfoler["path"]:
+                                report.append(disk)
+                                seen_paths.add(disk["path"])
+                                break
+                        else:
+                            for disk in diskspace_data:
+                                if disk["path"].startswith(rootfoler["path"]):
+                                    report.append(disk)
+                                    seen_paths.add(disk["path"])
+                                    break
+                            else:
+                                logging.warning("No diskspace data found for %s, using only available Data", rootfoler["path"])
+                                report.append({"path": rootfoler["path"], "freeSpace":  rootfoler["freeSpace"], "totalSpace": -1})
+                                seen_paths.add(rootfoler["path"])
+
                     return report
             return None
 


### PR DESCRIPTION
This pull request includes changes to the `root_folder` function in the `src/scraparr/connectors/__init__.py` file. The changes aim to improve the handling of disk space data by ensuring that paths are tracked and appropriately logged if no data is found.

Improvements to disk space data handling:

* Added a `seen_paths` set to keep track of added paths and avoid duplicates.
* Enhanced the nested loops to check for matching paths and log a warning if no disk space data is found for a given path, using only available data instead.