### PR TITLE
Skip Series that are deleted/with missing statistics

### DIFF
--- a/src/scraparr/connectors/sonarr.py
+++ b/src/scraparr/connectors/sonarr.py
@@ -3,6 +3,7 @@ Module to handle the Metrics of the Sonarr Service
 """
 
 import time
+import logging
 from dateutil.parser import parse
 
 from scraparr import util
@@ -83,10 +84,14 @@ def analyse_series(series, detailed, alias):
 
     for serie in series:
         title = serie["titleSlug"]
+        stats = serie["statistics"]
+
+        if not stats:
+            logging.warning("No statistics found for %s", title)
+            continue
 
         util.increase_quality_count(quality_count, serie["episodes"], serie["rootFolderPath"])
 
-        stats = serie["statistics"]
         root_folder = serie["rootFolderPath"]
 
         util.update_count(


### PR DESCRIPTION
This pull request includes changes to the `src/scraparr/connectors/sonarr.py` file to add logging functionality and improve the robustness of the `analyse_series` function. The most important changes include the addition of the logging module and the handling of missing statistics.

Improvements to logging and error handling:

* [`src/scraparr/connectors/sonarr.py`](diffhunk://#diff-f01b48335ab94f4725ad36a5eddc5e26fe659b356233fa758813b2de31a9cc6cR6): Added the `logging` module to the imports to enable logging functionality.
* [`src/scraparr/connectors/sonarr.py`](diffhunk://#diff-f01b48335ab94f4725ad36a5eddc5e26fe659b356233fa758813b2de31a9cc6cR87-L89): Modified the `analyse_series` function to log a warning message when no statistics are found for a series and to continue processing the next series without raising an error.