### PR TITLE
Rework prowlarr indexer status

### DIFF
--- a/src/scraparr/connectors/prowlarr.py
+++ b/src/scraparr/connectors/prowlarr.py
@@ -58,7 +58,7 @@ def check_health(health, res):
 
             # Extract the word(s) after the colon
             indexer_match = re.search(r": (.+)", message)
-            indexers = indexer_match.group(1) if indexer_match else None
+            indexers = indexer_match.group(1).split(', ') if indexer_match else None
             for indexer in res:
                 if indexer['name'] in indexers:
                     indexer['status'] = {"status": status}

--- a/src/scraparr/connectors/prowlarr.py
+++ b/src/scraparr/connectors/prowlarr.py
@@ -3,6 +3,7 @@ Module to handle the Metrics of the Prowlarr Service
 """
 
 import time
+import re
 from dateutil.parser import parse
 
 from scraparr.util import get
@@ -19,7 +20,15 @@ def get_indexers(url, api_key, version, alias):
     if res == {}:
         UP.labels(alias, 'prowlarr').set(0)
     else:
+        UP.labels(alias, 'prowlarr').set(1)
+        prowlarr_metrics.LAST_SCRAPE.labels(alias).set(end_time)
+        prowlarr_metrics.SCRAPE_DURATION.labels(alias).set(end_time - initial_time)
+
         status = get(f"{url}/api/{version}/indexerstatus", api_key)
+
+        if status == {}:
+            UP.labels(alias, 'prowlarr').set(0)
+            return res
 
         # Create a dictionary for fast lookup
         stat_dict = {stat['indexerId']: stat for stat in status}
@@ -27,12 +36,32 @@ def get_indexers(url, api_key, version, alias):
         # Update the status if the id matches
         for indexer in res:
             if indexer['id'] in stat_dict:
-                indexer['status'] = stat_dict[indexer['id']]
+                indexer['status'] = "disabled" if stat_dict[indexer['id']] else None
 
-        UP.labels(alias, 'prowlarr').set(1)
-        prowlarr_metrics.LAST_SCRAPE.labels(alias).set(end_time)
-        prowlarr_metrics.SCRAPE_DURATION.labels(alias).set(end_time - initial_time)
+        health = get(f"{url}/api/{version}/health", api_key)
+
+        if health == {}:
+            UP.labels(alias, 'prowlarr').set(0)
+            return res
+
+        check_health(health, res)
+
     return res
+
+def check_health(health, res):
+    """Check the Health of the Indexers"""
+    for notification in health:
+        if notification['source'] == 'IndexerStatusCheck':
+            message = notification['message']
+            status_match = re.search(r"Indexers (\w+)", message)
+            status = status_match.group(1) if status_match else None
+
+            # Extract the word(s) after the colon
+            indexer_match = re.search(r": (.+)", message)
+            indexers = indexer_match.group(1) if indexer_match else None
+            for indexer in res:
+                if indexer['name'] in indexers:
+                    indexer['status'] = {"status": status}
 
 def get_applications(url, api_key, version, alias):
     """Grab the Applications from the Prowlarr Endpoint"""
@@ -127,10 +156,13 @@ def analyse_indexers(indexers, detailed, alias):
                 .set(enabled)
             )
             if "status" in indexer:
-                status = indexer["status"].get("status", "unknown")
+                status = indexer["status"].get("status", "healthy")
             else:
-                status = "unknown"
-            prowlarr_metrics.INDEXER_STATUS.labels(alias, name, status).set(1)
+                status = "healthy"
+            if status == "healthy":
+                prowlarr_metrics.INDEXER_STATUS.labels(alias, name, status).set(1)
+            else:
+                prowlarr_metrics.INDEXER_STATUS.labels(alias, name, status).set(0)
 
     for types, counts in indexer_count.items():
         if types == "total":

--- a/src/scraparr/metrics/prowlarr.py
+++ b/src/scraparr/metrics/prowlarr.py
@@ -23,4 +23,4 @@ INDEXER_PRIVACY = Gauge("prowlarr_indexer_privacy", "Privacy status of the Index
 INDEXER_ENABLED_T = Gauge("prowlarr_indexer_enabled_total", "Enabled status of the Indexers", ["alias"])
 INDEXER_PRIVACY_T = Gauge("prowlarr_indexer_privacy_total", "Privacy status of the Indexers", ["alias", "privacy"])
 VIP_EXPIRATION = Gauge("prowlarr_vip_expiration", "VIP Expiration of the Indexers", ["alias", "indexer"])
-INDEXER_STATUS = Gauge("prowlarr_indexer_status", "Status of the Indexers", ["alias", "indexer", "status"])
+INDEXER_STATUS = Gauge("prowlarr_indexer_status", "Status of the Indexers value 0 is unhealthy, 1 is healthy", ["alias", "indexer", "status"])


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and accuracy of the `prowlarr` connector in the `scraparr` project. The most important changes involve enhancing the monitoring and health-checking capabilities of the indexers.

Enhancements to monitoring and health-checking:

* [`src/scraparr/connectors/prowlarr.py`](diffhunk://#diff-93ce7a7032828bbeb3a7414c7834ee21dc34c971f1bdf4a8127abc60b87735adR6): Imported the `re` module to facilitate regular expression operations.
* [`src/scraparr/connectors/prowlarr.py`](diffhunk://#diff-93ce7a7032828bbeb3a7414c7834ee21dc34c971f1bdf4a8127abc60b87735adR23-R65): Added metrics for the last scrape time and scrape duration, and introduced a new `check_health` function to assess the health of indexers based on notifications.
* [`src/scraparr/connectors/prowlarr.py`](diffhunk://#diff-93ce7a7032828bbeb3a7414c7834ee21dc34c971f1bdf4a8127abc60b87735adL130-R165): Updated the `analyse_indexers` function to categorize indexer status as "healthy" instead of "unknown" by default, and adjusted the metrics accordingly.

Clarification of metric descriptions:

* [`src/scraparr/metrics/prowlarr.py`](diffhunk://#diff-0a4e7393d19aea4229f4f55bca1a258822b9da6df16a6243c5062908e60a8ecfL26-R26): Updated the description of the `INDEXER_STATUS` metric to clarify that a value of 0 indicates an unhealthy status and a value of 1 indicates a healthy status.