### PR TITLE
Add Fallback to Stats Data

### DIFF
--- a/src/scraparr/connectors/sonarr.py
+++ b/src/scraparr/connectors/sonarr.py
@@ -84,7 +84,7 @@ def analyse_series(series, detailed, alias):
 
     for serie in series:
         title = serie["titleSlug"]
-        stats = serie["statistics"]
+        stats = serie.get("statistics", None)
 
         if not stats:
             logging.warning("No statistics found for %s", title)

--- a/src/scraparr/connectors/sonarr.py
+++ b/src/scraparr/connectors/sonarr.py
@@ -86,7 +86,7 @@ def analyse_series(series, detailed, alias):
         title = serie["titleSlug"]
         stats = serie.get("statistics", None)
 
-        if not stats:
+        if stats is None:
             logging.warning("No statistics found for %s", title)
             continue
 


### PR DESCRIPTION
This pull request includes a small change to the `analyse_series` function in the `src/scraparr/connectors/sonarr.py` file. The change modifies how the `statistics` attribute is accessed to prevent potential errors when the attribute is missing.

* [`src/scraparr/connectors/sonarr.py`](diffhunk://#diff-f01b48335ab94f4725ad36a5eddc5e26fe659b356233fa758813b2de31a9cc6cL87-R87): Changed the access of the `statistics` attribute in the `analyse_series` function to use the `get` method with a default value of `None`.