### PR TITLE
Add Check if Series has stats, else skip it

### DIFF
--- a/src/scraparr/connectors/sonarr.py
+++ b/src/scraparr/connectors/sonarr.py
@@ -3,6 +3,7 @@ Module to handle the Metrics of the Sonarr Service
 """
 
 import time
+import logging
 from datetime import datetime
 from scraparr import util
 from scraparr.metrics.general import UP
@@ -60,10 +61,14 @@ def analyse_series(series, detailed):
 
     for serie in series:
         title = serie["titleSlug"]
+        stats = serie.get("statistics", None)
+
+        if stats is None:
+            logging.warning("No statistics found for %s", title)
+            continue
 
         util.increase_quality_count(quality_count, serie["episodes"], serie["rootFolderPath"])
 
-        stats = serie["statistics"]
         root_folder = serie["rootFolderPath"]
 
         util.update_count(


### PR DESCRIPTION
This pull request includes updates to the `src/scraparr/connectors/sonarr.py` file to enhance logging and handle missing statistics more gracefully.

Logging improvements:

* Added the `logging` import to enable logging functionality.
* Introduced a warning log message when no statistics are found for a series in the `analyse_series` function.

Error handling:

* Modified the `analyse_series` function to check for the presence of statistics and skip processing if they are missing, preventing potential errors.