### PR TITLE
Add multi Platform Support for Release Image and update names of Image Workflows

### DIFF
--- a/.github/workflows/main-image.yml
+++ b/.github/workflows/main-image.yml
@@ -1,5 +1,5 @@
 #
-name: Create and publish a Docker image
+name: Create and publish the Main Docker Image
 
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,5 +1,5 @@
 #
-name: Create and publish a Docker image
+name: Create and publish a Release Image
 
 # Configures this workflow to run every time a change is pushed to the branch called `release`.
 on:
@@ -42,6 +42,13 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@4574d27a4764455b42196d70a065bc6853246a25
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca
+
       # This step uses [docker/metadata-action](https://github.com/docker/metadata-action#about) to extract tags and labels that will be applied to the specified image. The `id` "meta" allows the output of this step to be referenced in a subsequent step. The `images` value provides the base name for the tags and labels.
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -63,6 +70,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
       


### PR DESCRIPTION
This pull request includes updates to the workflow files to improve the naming conventions and setup for building and publishing Docker images. The most important changes include renaming the workflows for clarity and adding new setup steps for QEMU and Docker Buildx.

Workflow improvements:

* [`.github/workflows/main-image.yml`](diffhunk://#diff-92e1b943668296f809f801b228f9b341bc5a53e51ac0158d90509dcffd6e49bfL2-R2): Renamed the workflow to "Create and publish the Main Docker Image" for better clarity.
* [`.github/workflows/publish-image.yml`](diffhunk://#diff-20a6c39db0bdbf998cfc2078fa28cc6734ee3dd8efd0a7edab29379b6ed95aa8L2-R2): Renamed the workflow to "Create and publish a Release Image" for better clarity.

Setup enhancements:

* [`.github/workflows/publish-image.yml`](diffhunk://#diff-20a6c39db0bdbf998cfc2078fa28cc6734ee3dd8efd0a7edab29379b6ed95aa8R45-R51): Added steps to set up QEMU and Docker Buildx to support multi-platform builds.
* [`.github/workflows/publish-image.yml`](diffhunk://#diff-20a6c39db0bdbf998cfc2078fa28cc6734ee3dd8efd0a7edab29379b6ed95aa8R73): Updated the build step to specify platforms `linux/amd64` and `linux/arm64` for multi-platform support.