### PR TITLE
fix prowlarr scrape

### DIFF
--- a/src/scraparr/connectors/__init__.py
+++ b/src/scraparr/connectors/__init__.py
@@ -59,7 +59,7 @@ class Connectors:
         config = self.connectors[service][config_index]["config"]
         scrape_data = {"data": self.connectors[service][config_index]["function"].scrape(config),
                        "system": self.get_system_data(service, config)}
-        if scrape_data["data"] != {} and scrape_data["system"] != {}:
+        if not scrape_data["data"] and not scrape_data["system"]:
             new_hash = self.get_hash(scrape_data)
             if new_hash != self.last_scrape[service][config_index]:
                 self.last_scrape[service][config_index] = new_hash
@@ -130,8 +130,9 @@ class Connectors:
         else:
             data = {'status': status()}
 
-        if any(value is {} for value in data.values()):
-            logging.warning("At least One Data is missing for %s, %s", service, config.get('alias', ""))
+        if any(value == {} for value in data.values()):
+            logging.warning("At least One Data is missing for %s, %s",
+                            service, config.get('alias', ""))
             return {}
         return data
 

--- a/src/scraparr/connectors/prowlarr.py
+++ b/src/scraparr/connectors/prowlarr.py
@@ -61,7 +61,7 @@ def check_health(health, res):
             indexers = indexer_match.group(1).split(', ') if indexer_match else None
             for indexer in res:
                 if indexer['name'] in indexers:
-                    indexer['status'] = {"status": status}
+                    indexer['status'] = status
 
 def get_applications(url, api_key, version, alias):
     """Grab the Applications from the Prowlarr Endpoint"""


### PR DESCRIPTION
This pull request includes changes to the `scraparr` project, focusing on improving the handling of empty dictionaries and fixing a status assignment bug in the `prowlarr` connector. The most important changes are grouped into two themes: handling empty dictionaries and fixing status assignment.

Handling empty dictionaries:

* [`src/scraparr/connectors/__init__.py`](diffhunk://#diff-ca5239811e8dcf570d0cb4e41ff252fca1440d1ca44aecbc9fc0cf55382cb382L62-R62): Modified the condition to check for empty dictionaries using `not` instead of comparing directly to `{}` in the `scrape_service` method.
* [`src/scraparr/connectors/__init__.py`](diffhunk://#diff-ca5239811e8dcf570d0cb4e41ff252fca1440d1ca44aecbc9fc0cf55382cb382L133-R135): Changed the condition in the `status` method to use `== {}` instead of `is {}` to correctly identify empty dictionaries.

Fixing status assignment:

* [`src/scraparr/connectors/prowlarr.py`](diffhunk://#diff-93ce7a7032828bbeb3a7414c7834ee21dc34c971f1bdf4a8127abc60b87735adL64-R64): Corrected the assignment of the `status` field in the `check_health` method by removing the redundant dictionary wrapping.