### PR TITLE
Add Support for Overseerr

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -56,4 +56,11 @@ jellyseerr:
   api_key: key
   # alias: jellyseerr # Optional to Differentiate between multiple Services
   # interval: 30 # Optional to set a different Interval in Seconds
-  # detailed: true  # Get Data per Series
+  # detailed: true  # Get Data per Request/Issue
+
+overseerr:
+  url: http://overseerr:5055
+  api_key: key
+  # alias: overseerr # Optional to Differentiate between multiple Services
+  # interval: 30 # Optional to set a different Interval in Seconds
+  # detailed: true  # Get Data per Request/Issue

--- a/src/scraparr/connectors/__init__.py
+++ b/src/scraparr/connectors/__init__.py
@@ -26,7 +26,8 @@ class Connectors:
             "prowlarr": "v1", 
             "bazarr": "dummy",
             "readarr": "v1",
-            "jellyseerr": "v1"
+            "jellyseerr": "v1",
+            "overseerr": "v1",
         }
 
         if importer:

--- a/src/scraparr/connectors/overseerr.py
+++ b/src/scraparr/connectors/overseerr.py
@@ -1,0 +1,26 @@
+"""Module to handle the overseerr Connector"""
+
+import scraparr.connectors.seer
+import scraparr.metrics.overseerr as overseerr_metrics
+
+def scrape(config):
+    """Function to Scrape the Overseerr Service"""
+
+    if config.get("alias", None) is None:
+        config["alias"] = "overseerr"
+    if not config.get("service", None) is None:
+        config["service"] = "overseerr"
+
+    get_seer = scraparr.connectors.seer.GetSeer(config, overseerr_metrics)
+    users, requests, issues = get_seer.get()
+
+    if not users or not requests or not issues:
+        return None
+
+    return {"users": users, "requests": requests, "issues": issues}
+
+def update_metrics(data, detailed, alias):
+    """Update the Metrics for the Overseerr Service"""
+
+    update_seer = scraparr.connectors.seer.UpdateSeer(detailed, alias, overseerr_metrics)
+    update_seer.update(data)

--- a/src/scraparr/metrics/overseerr.py
+++ b/src/scraparr/metrics/overseerr.py
@@ -1,0 +1,34 @@
+"""Module to declare the overseerr Metrics"""
+
+from prometheus_client import Gauge
+
+# Scraping Stats
+LAST_SCRAPE = Gauge('overseerr_last_scrape', 'Last time overseerr was scraped', ['alias'] )
+SCRAPE_DURATION = Gauge('overseerr_scrape_duration', 'Duration of overseerr scrape', ['alias'] )
+
+# User Stats
+USER_COUNT = Gauge('overseerr_user_total', 'Number of users in overseerr', ['alias'])
+USER_REQUEST_COUNT = Gauge('overseerr_user_requests', 'Number of requests per user in overseerr', ['alias', 'user'])
+
+# Request Stats
+
+REQUEST_COUNT = Gauge('overseerr_request_total', 'Number of requests in overseerr', ['alias'])
+REQUEST_TV = Gauge('overseerr_request_tv', 'Number of TV requests in overseerr', ['alias'])
+REQUEST_MOVIE = Gauge('overseerr_request_movie', 'Number of Movie requests in overseerr', ['alias'])
+REQUEST_STATUS = Gauge('overseerr_request_status', 'Status of the request in overseerr', ['alias', 'status'])
+REQUEST_SEASONS_T = Gauge('overseerr_request_seasons_total', 'Total number of Requested Seasons in overseerr', ['alias'])
+# Detailed
+REQUEST_TIMESTAMP = Gauge('overseerr_request_timestamp', 'Timestamp of the request in overseerr', ['alias', 'request'])
+REQUEST_SEASONS = Gauge('overseerr_request_seasons', 'Number of seasons in the request in overseerr', ['alias', 'request'])
+
+# Issue Stats
+
+ISSUE_COUNT = Gauge('overseerr_issue_total', 'Number of issues in overseerr', ['alias'])
+ISSUE_STATUS = Gauge('overseerr_issue_status', 'Status of the issue in overseerr', ['alias', 'status'])
+ISSUE_TYPE = Gauge('overseerr_issue_type', 'Type of the issue in overseerr', ['alias', 'type'])
+ISSUE_MEDIA_TYPE = Gauge('overseerr_issue_media_type', 'Media Type of the issue in overseerr', ['alias', 'media_type'])
+ISSUE_AND_MEDIA_TYPE = Gauge('overseerr_issue_and_media_type', 'Issue and Media Type of the issue in overseerr', ['alias', 'issue_type', 'media_type'])
+# Detailed
+ISSUE_TITLE = Gauge('overseerr_issue_title', 'Title of the issue in overseerr', ['alias', 'issue'])
+ISSUE_CREATED = Gauge('overseerr_issue_created', 'Created time of the issue in overseerr', ['alias', 'issue'])
+ISSUE_UPDATED = Gauge('overseerr_issue_updated', 'Update time of the issue in overseerr', ['alias', 'issue'])

--- a/src/scraparr/scraparr.py
+++ b/src/scraparr/scraparr.py
@@ -50,7 +50,8 @@ ACTIVE_CONNECTORS = [
     'prowlarr',
     'bazarr',
     'readarr',
-    'jellyseerr'
+    'jellyseerr',
+    'overseerr',
 ]
 BEAUTIFUL_CONNECTORS = ", ".join(ACTIVE_CONNECTORS[:-1]) + " or " + ACTIVE_CONNECTORS[-1]
 


### PR DESCRIPTION
This pull request introduces support for the `overseerr` service in addition to the existing `jellyseerr` service. The most important changes include updates to configuration files, connector handling, and metric definitions.

Configuration updates:
* [`config.yaml`](diffhunk://#diff-d8d0422389f03d783e32e627250fe29834bd09c6361640d1ff00661dd6820034L59-R66): Added configuration options for the `overseerr` service, including URL, API key, alias, interval, and detailed data settings.

Connector handling:
* [`src/scraparr/connectors/__init__.py`](diffhunk://#diff-ca5239811e8dcf570d0cb4e41ff252fca1440d1ca44aecbc9fc0cf55382cb382L29-R30): Added `overseerr` to the list of supported services in the `add_connector` method.
* [`src/scraparr/connectors/overseerr.py`](diffhunk://#diff-c60e6711a5052ccab5dc28f9c02ae172c01bc2b6787ffc4b195328387798c2ffR1-R26): Created a new module to handle the `overseerr` connector, including functions for scraping service data and updating metrics.

Metric definitions:
* [`src/scraparr/metrics/overseerr.py`](diffhunk://#diff-83e65cc16d1dbde138ae9be7d6d1a79b6ea2c20b04e485eaf1cc53445c3fd16fR1-R34): Defined various metrics for the `overseerr` service, such as scraping stats, user stats, request stats, and issue stats.

Additional updates:
* [`src/scraparr/scraparr.py`](diffhunk://#diff-e62ee6aa3cd382bab2ba7d3af815a0e489ab167fc59a40082517926f7aac956eL53-R54): Added `overseerr` to the list of active connectors.