### PR TITLE
Switch to dev branch and add Readme Notice

### DIFF
--- a/.github/workflows/main-image.yml
+++ b/.github/workflows/main-image.yml
@@ -5,7 +5,7 @@ name: Create and publish the Main Docker Image
 on:
   push:
     branches:
-      - main
+      - dev
     paths:
       - 'src/**'
       - 'Dockerfile'

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Docker Hub:
 > [!NOTE]  
 > If your using any v1 Version check the Readme of the [v1 Branch](https://github.com/thecfu/scraparr/tree/v1#readme)
 
+> [!NOTE]  
+> If you want to access new features before they are released, use the `main` tag.
+> 
+
 ### Kubernetes
 
 Deployment on Kubernetes is possible via the [imgios/scraparr](https://github.com/imgios/scraparr) Helm Chart, which simplifies the process into two steps:


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow and updates to the README file to provide additional information.

GitHub Actions workflow update:
* [`.github/workflows/main-image.yml`](diffhunk://#diff-92e1b943668296f809f801b228f9b341bc5a53e51ac0158d90509dcffd6e49bfL8-R8): Changed the branch trigger from `main` to `dev` for the Docker image creation and publishing workflow.

Documentation update:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R49-R52): Added a note about using the `main` tag to access new features before they are officially released.