### PR TITLE
Interval setting not being respected

### DIFF
--- a/src/scraparr/connectors/__init__.py
+++ b/src/scraparr/connectors/__init__.py
@@ -95,7 +95,7 @@ class Connectors:
             futures = []
             for service, configs in self.connectors.items():
                 for config_index, config in enumerate(configs):
-                    interval = config.get('interval', 30)
+                    interval = config["config"].get('interval', 30)
                     futures.append(executor.submit(
                         scrape_with_interval,
                         service,


### PR DESCRIPTION
This pull request includes a small change to the `scrape_with_interval` function in the `src/scraparr/connectors/__init__.py` file. The change modifies how the interval is retrieved from the configuration dictionary.

* [`src/scraparr/connectors/__init__.py`](diffhunk://#diff-ca5239811e8dcf570d0cb4e41ff252fca1440d1ca44aecbc9fc0cf55382cb382L98-R98): Changed the interval retrieval to use `config["config"].get('interval', 30)` instead of `config.get('interval', 30)` in the `scrape_with_interval` function.