### PR TITLE
Add the API-Url to the Request Error Logging

### DIFF
--- a/src/scraparr/connectors/util.py
+++ b/src/scraparr/connectors/util.py
@@ -15,13 +15,13 @@ def get(api_url, api_key):
         if r.status_code == 200:
             return r.json()
         if r.status_code == 401:
-            logging.error("Unauthorized: %s", r.status_code)
+            logging.error("Unauthorized when trying to access %s: %s", api_url, r.status_code)
         elif r.status_code == 404:
-            logging.error("Not Found, check API Version and Docs: %s", r.status_code)
+            logging.error("Not Found, check API Version and Docs: %s, returned HTML %s", api_url, r.status_code)
         else:
-            logging.error("Error: %s", r.status_code)
+            logging.error("Request for %s returned unexpected HTML Status Code: %s", api_url, r.status_code)
     except requests.exceptions.RequestException as e:
-        logging.error("Error: %s", e)
+        logging.error("Request for %s failed with: %s", api_url, e)
     return {}
 
 

--- a/src/scraparr/connectors/util.py
+++ b/src/scraparr/connectors/util.py
@@ -17,9 +17,11 @@ def get(api_url, api_key):
         if r.status_code == 401:
             logging.error("Unauthorized when trying to access %s: %s", api_url, r.status_code)
         elif r.status_code == 404:
-            logging.error("Not Found, check API Version and Docs: %s, returned HTML %s", api_url, r.status_code)
+            logging.error("Not Found, check API Version and Docs: %s, returned HTML %s",
+                          api_url, r.status_code)
         else:
-            logging.error("Request for %s returned unexpected HTML Status Code: %s", api_url, r.status_code)
+            logging.error("Request for %s returned unexpected HTML Status Code: %s",
+                          api_url, r.status_code)
     except requests.exceptions.RequestException as e:
         logging.error("Request for %s failed with: %s", api_url, e)
     return {}


### PR DESCRIPTION
This pull request includes improvements to the error logging in the `get` function within the `src/scraparr/connectors/util.py` file. The changes enhance the clarity of error messages by incorporating the `api_url` into the log outputs.

Enhancements to error logging:

* [`src/scraparr/connectors/util.py`](diffhunk://#diff-89fcfa41fabcdc03e26d8af09f12336da87521a4fbd5c13ed2267e5185e5883fL18-R24): Updated error messages to include the `api_url` for better context when logging unauthorized access, not found errors, unexpected status codes, and request failures.