### PR TITLE
fix: rework clear logic to prevent the clearing of a second instance

### DIFF
--- a/src/scraparr/connectors/__init__.py
+++ b/src/scraparr/connectors/__init__.py
@@ -10,6 +10,8 @@ import logging
 import concurrent.futures
 
 from scraparr.const import API_VERSIONS
+from scraparr.metrics.clear import clear
+
 
 class Connectors:
     """Class to initialize Variables that are used to Identify the Connectors
@@ -79,6 +81,7 @@ class Connectors:
 
         def scrape_with_interval(service, config_index, interval):
             while running:
+                clear(service)
                 self.scrape_service(service, config_index)
                 time.sleep(interval)
 

--- a/src/scraparr/connectors/bazarr.py
+++ b/src/scraparr/connectors/bazarr.py
@@ -72,9 +72,6 @@ def get_wanted(url, api_key):
 def analyse_data(data, wanted, detailed, alias):
     """Analyse the Data and set the Correct Metrics"""
 
-    bazarr_metrics.WANTED_EPISODE_COUNT.clear()
-    bazarr_metrics.WANTED_MOVIE_COUNT.clear()
-
     wanted_episodes = {}
     wanted_movies = {}
     count = {"movies": 0, "series": 0}
@@ -110,7 +107,6 @@ def analyse_providers(providers, alias):
     """Analyse the Providers and set the Correct Metrics"""
 
     bazarr_metrics.PROVIDER_COUNT.labels(alias).set(len(providers["data"]))
-    bazarr_metrics.PROVIDER_STATUS.clear()
 
     for provider in providers["data"]:
         bazarr_metrics.PROVIDER_STATUS.labels(alias, provider["name"], provider["status"]).set(1)

--- a/src/scraparr/connectors/prowlarr.py
+++ b/src/scraparr/connectors/prowlarr.py
@@ -128,10 +128,6 @@ def analyse_indexers(indexers, detailed, alias):
         "torrent": {"total": 0, "enabled": 0, "private": 0, "public": 0, "semiPrivate": 0}
     }
 
-    prowlarr_metrics.VIP_EXPIRATION.clear()
-    prowlarr_metrics.INDEXER_STATUS.clear()
-    prowlarr_metrics.INDEXER_ENABLED.clear()
-
     for indexer in indexers:
         enabled = 1 if indexer["enable"] else 0
         indexer_count["total"]["enabled"] += enabled

--- a/src/scraparr/connectors/radarr.py
+++ b/src/scraparr/connectors/radarr.py
@@ -32,12 +32,6 @@ def get_movies(url, api_key, version, alias):
 def analyse_movies(movies, detailed, alias):
     """Analyse the Movies and set the Correct Metrics"""
 
-    # Reset Titled Metrics to insure deletion of old Movies
-    radarr_metrics.MOVIE_FILE_COUNT.clear()
-    radarr_metrics.MOVIE_DISK_SIZE.clear()
-    radarr_metrics.MOVIE_MONITORED.clear()
-    radarr_metrics.MOVIE_MISSING.clear()
-
     status_labels = {
         "tba": {
             "func": [radarr_metrics.TBA_MOVIES, radarr_metrics.TBA_MOVIES_T],

--- a/src/scraparr/connectors/readarr.py
+++ b/src/scraparr/connectors/readarr.py
@@ -57,12 +57,6 @@ def analyse_authors(authors, detailed, alias):
     authors_status = {}
     author_rating = []
 
-    readarr_metrics.AUTHOR_BOOK_COUNT.clear()
-    readarr_metrics.AUTHOR_STATUS.clear()
-    readarr_metrics.AUTHOR_DISK_SIZE.clear()
-    readarr_metrics.AUTHOR_RATING.clear()
-    readarr_metrics.AUTHOR_RATING_TOTAL.clear()
-
     for author in authors:
         status = author.get("status", "Unknown")
         authors_status[status] = author.get(status, 0) + 1
@@ -97,11 +91,6 @@ def analyse_books(books, detailed, alias):
     book_genres = {}
     book_disk_size = []
     book_rating = []
-
-    readarr_metrics.BOOK_DISK_SIZE.clear()
-    readarr_metrics.BOOK_PERCENTAGE.clear()
-    readarr_metrics.BOOK_RATING.clear()
-    readarr_metrics.BOOK_RATING_TOTAL.clear()
 
     for book in books:
 

--- a/src/scraparr/connectors/seerr.py
+++ b/src/scraparr/connectors/seerr.py
@@ -236,9 +236,6 @@ class UpdateSeerr:
         request_count = {}
         requested_seasons = 0
 
-        self.metrics.REQUEST_TIMESTAMP.clear()
-        self.metrics.REQUEST_SEASONS.clear()
-
         for request in requests:
             request_status[request["status"]] = request_status.get(request["status"], 0) + 1
             request_count[request["type"]] = request_count.get(request["type"], 0) + 1
@@ -270,11 +267,6 @@ class UpdateSeerr:
         issue_media_type = {}
         issue_and_media_type = {}
         issue_title = {}
-
-        self.metrics.ISSUE_TITLE.clear()
-        self.metrics.ISSUE_CREATED.clear()
-        self.metrics.ISSUE_UPDATED.clear()
-        self.metrics.ISSUE_TITLE.clear()
 
         for issue in issues:
             issue_status[issue["status"]] = issue_status.get(issue["status"], 0) + 1

--- a/src/scraparr/connectors/sonarr_api.py
+++ b/src/scraparr/connectors/sonarr_api.py
@@ -86,14 +86,6 @@ class SonarrApi:
             }
         }
 
-        # Reset Titled Metrics to insure deletion of old Series
-        self.metrics.SERIES_EPISODE_COUNT.clear()
-        self.metrics.SERIES_MISSING_EPISODE_COUNT.clear()
-        self.metrics.SERIES_COUNT.clear()
-        self.metrics.SERIES_DISK_SIZE.clear()
-        self.metrics.SERIES_DOWNLOAD_PERCENTAGE.clear()
-        self.metrics.SERIES_MONITORED.clear()
-
         for serie in series:
             title = serie["titleSlug"]
             stats = serie.get("statistics", None)

--- a/src/scraparr/metrics/clear.py
+++ b/src/scraparr/metrics/clear.py
@@ -1,0 +1,120 @@
+"""Clear metrics for various services in Scraparr."""
+
+import scraparr.metrics.prowlarr as prowlarr_metrics
+import scraparr.metrics.radarr as radarr_metrics
+import scraparr.metrics.bazarr as bazarr_metrics
+import scraparr.metrics.readarr as readarr_metrics
+import scraparr.metrics.jellyseerr as jellyseerr_metrics
+import scraparr.metrics.overseerr as overseerr_metrics
+import scraparr.metrics.sonarr as sonarr_metrics
+import scraparr.metrics.whisparr as whisparr_metrics
+
+
+def clear(service):
+    """
+    Clear the metrics for the specified service.
+    :param service: The service for which to clear metrics.
+    """
+    if service == "prowlarr":
+        clearProwlarrMetrics()
+    elif service == "radarr":
+        clearRadarrMetrics()
+    elif service == "bazarr":
+        clearBazarrMetrics()
+    elif service == "readarr":
+        clearReadarrMetrics()
+    elif service == "jellyseerr":
+        clearJellyseerrMetrics()
+    elif service == "overseerr":
+        clearOverseerrMetrics()
+    elif service == "sonarr":
+        clearSonarrMetrics()
+    elif service == "whisparr":
+        clearWhisparrMetrics()
+
+def clearProwlarrMetrics():
+    """
+    Clear all metrics with labels to remove any previous data.
+    """
+    prowlarr_metrics.VIP_EXPIRATION.clear()
+    prowlarr_metrics.INDEXER_STATUS.clear()
+    prowlarr_metrics.INDEXER_ENABLED.clear()
+
+def clearRadarrMetrics():
+    """
+    Clear all Radarr metrics to remove any previous data.
+    """
+    radarr_metrics.MOVIE_FILE_COUNT.clear()
+    radarr_metrics.MOVIE_DISK_SIZE.clear()
+    radarr_metrics.MOVIE_MONITORED.clear()
+    radarr_metrics.MOVIE_MISSING.clear()
+
+def clearBazarrMetrics():
+    """
+    Clear all Bazarr metrics to remove any previous data.
+    """
+
+    bazarr_metrics.WANTED_EPISODE_COUNT.clear()
+    bazarr_metrics.WANTED_MOVIE_COUNT.clear()
+    bazarr_metrics.PROVIDER_STATUS.clear()
+
+def clearReadarrMetrics():
+    """
+    Clear all Readarr metrics to remove any previous data.
+    """
+
+    readarr_metrics.BOOK_DISK_SIZE.clear()
+    readarr_metrics.BOOK_PERCENTAGE.clear()
+    readarr_metrics.BOOK_RATING.clear()
+    readarr_metrics.BOOK_RATING_TOTAL.clear()
+    readarr_metrics.AUTHOR_BOOK_COUNT.clear()
+    readarr_metrics.AUTHOR_STATUS.clear()
+    readarr_metrics.AUTHOR_DISK_SIZE.clear()
+    readarr_metrics.AUTHOR_RATING.clear()
+    readarr_metrics.AUTHOR_RATING_TOTAL.clear()
+
+def clearJellyseerrMetrics():
+    """
+    Clear all Jellyseerr metrics to remove any previous data.
+    """
+
+    jellyseerr_metrics.REQUEST_TIMESTAMP.clear()
+    jellyseerr_metrics.REQUEST_SEASONS.clear()
+    jellyseerr_metrics.ISSUE_TITLE.clear()
+    jellyseerr_metrics.ISSUE_CREATED.clear()
+    jellyseerr_metrics.ISSUE_UPDATED.clear()
+    jellyseerr_metrics.ISSUE_TITLE.clear()
+
+def clearOverseerrMetrics():
+    """
+    Clear all Overseerr metrics to remove any previous data.
+    """
+
+    overseerr_metrics.REQUEST_TIMESTAMP.clear()
+    overseerr_metrics.REQUEST_SEASONS.clear()
+    overseerr_metrics.ISSUE_TITLE.clear()
+    overseerr_metrics.ISSUE_CREATED.clear()
+    overseerr_metrics.ISSUE_UPDATED.clear()
+    overseerr_metrics.ISSUE_TITLE.clear()
+
+def clearSonarrMetrics():
+    """
+    Clear all Sonarr metrics to remove any previous data.
+    """
+    sonarr_metrics.SERIES_EPISODE_COUNT.clear()
+    sonarr_metrics.SERIES_MISSING_EPISODE_COUNT.clear()
+    sonarr_metrics.SERIES_COUNT.clear()
+    sonarr_metrics.SERIES_DISK_SIZE.clear()
+    sonarr_metrics.SERIES_DOWNLOAD_PERCENTAGE.clear()
+    sonarr_metrics.SERIES_MONITORED.clear()
+
+def clearWhisparrMetrics():
+    """
+    Clear all Whisparr metrics to remove any previous data.
+    """
+    whisparr_metrics.SERIES_EPISODE_COUNT.clear()
+    whisparr_metrics.SERIES_MISSING_EPISODE_COUNT.clear()
+    whisparr_metrics.SERIES_COUNT.clear()
+    whisparr_metrics.SERIES_DISK_SIZE.clear()
+    whisparr_metrics.SERIES_DOWNLOAD_PERCENTAGE.clear()
+    whisparr_metrics.SERIES_MONITORED.clear()


### PR DESCRIPTION
This pull request introduces a new centralized `clear` function for resetting metrics across various services in Scraparr, replacing repetitive metric-clearing code with a more modular and maintainable approach. The changes include the addition of the `clear` function and its integration into multiple service-specific methods.

### Centralized Metric Clearing Implementation:
* A new `clear` function and associated service-specific clearing functions were added in `src/scraparr/metrics/clear.py` to centralize and modularize the clearing of metrics for different services. This includes functions like `clearProwlarrMetrics`, `clearRadarrMetrics`, and others.

### Refactoring of Service-Specific Metric Clearing:
* The `clear` function is now invoked within the `scrape_with_interval` method in `src/scraparr/connectors/__init__.py`, replacing direct metric-clearing logic.
* Removed inline metric-clearing calls from service-specific methods in various files (`bazarr.py`, `prowlarr.py`, `radarr.py`, `readarr.py`, `seerr.py`, and `sonarr_api.py`) and replaced them with the centralized `clear` function. [[1]](diffhunk://#diff-e3613046c705e39c306c95b4b6c3d40cee7118a2d0126c593df96be790ffff24L75-L77) [[2]](diffhunk://#diff-93ce7a7032828bbeb3a7414c7834ee21dc34c971f1bdf4a8127abc60b87735adL131-L134) [[3]](diffhunk://#diff-9e2f76806cce2591d3bc0233ca82f9d17d2a73922f173abed9eac0e207908503L35-L40) [[4]](diffhunk://#diff-22c23b0e28015255032e2499fadd2fd9ad3dbc7c7ccb2283fa1c8c15c4a48be3L60-L65) [[5]](diffhunk://#diff-de52a92ee931b576c9bae40bce005d274c4fe8f92cd9569aaf45ecf369c470b1L239-L241) [[6]](diffhunk://#diff-908d0e602808a3958770f057c5a2dc905348e51406caa8143da31ea569d36479L89-L96)

### Code Simplification and Maintenance:
* Removed redundant `clear` calls for metrics in service-specific files, reducing code duplication and improving maintainability. [[1]](diffhunk://#diff-e3613046c705e39c306c95b4b6c3d40cee7118a2d0126c593df96be790ffff24L113) [[2]](diffhunk://#diff-22c23b0e28015255032e2499fadd2fd9ad3dbc7c7ccb2283fa1c8c15c4a48be3L101-L105) [[3]](diffhunk://#diff-de52a92ee931b576c9bae40bce005d274c4fe8f92cd9569aaf45ecf369c470b1L274-L278)

These changes aim to streamline the codebase, making it easier to manage and extend metric-clearing functionality across services.