### PR TITLE
update sonarr and radarr dashboards to sort quality and genre by counts

### DIFF
--- a/dashboards/dashboard1.json
+++ b/dashboards/dashboard1.json
@@ -1686,11 +1686,12 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "readarr_book_genres{job=~\"$job\", alias=\"$readarr\"}",
+          "expr": "sort_desc(readarr_book_genres{job=~\"$job\", alias=\"$readarr\"})",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "legendFormat": "__auto",
-          "range": true,
+          "range": false,
+          "instant": true,
           "refId": "A",
           "useBackend": false
         }

--- a/dashboards/dashboard1.json
+++ b/dashboards/dashboard1.json
@@ -4221,11 +4221,12 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sonarr_quality_episodes_total{job=~\"$job\", alias=\"$sonarr\"}",
+          "expr": "sort_desc(sonarr_quality_episodes_total{job=~\"$job\", alias=\"$sonarr\"})",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "legendFormat": "__auto",
-          "range": true,
+          "instant": true,
+          "range": false,
           "refId": "A",
           "useBackend": false
         }
@@ -4317,11 +4318,12 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sonarr_genres_count_total{job=~\"$job\", alias=\"$sonarr\"}",
+          "expr": "sort_desc(sonarr_genres_count_total{job=~\"$job\", alias=\"$sonarr\"})",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "legendFormat": "__auto",
-          "range": true,
+          "instant": true,
+          "range": false,
           "refId": "A",
           "useBackend": false
         }
@@ -5047,11 +5049,12 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "radarr_quality_movies_total{job=~\"$job\", alias=\"$radarr\"}",
+          "expr": "sort_desc(radarr_quality_movies_total{job=~\"$job\", alias=\"$radarr\"})",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "legendFormat": "__auto",
-          "range": true,
+          "instant": true,
+          "range": false,
           "refId": "A",
           "useBackend": false
         }
@@ -5143,11 +5146,12 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "radarr_genres_count_total{job=~\"$job\", alias=\"$radarr\"}",
+          "expr": "sort_desc(radarr_genres_count_total{job=~\"$job\", alias=\"$radarr\"})",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "legendFormat": "__auto",
-          "range": true,
+          "instant": true,
+          "range": false,
           "refId": "A",
           "useBackend": false
         }


### PR DESCRIPTION
this fixes #129 to sort sonarr and radarr quality and genre bar gauge graphs by count. 

Probably could do the same across the board to all the other dashboards, but I don't use the other dashboards. 

<img width="1122" height="384" alt="Screenshot 2025-11-08 at 9 39 24 PM" src="https://github.com/user-attachments/assets/d3e495df-ab00-4e2c-9a75-5ff8c31ee92f" />
