### PR TITLE
fix scrape interval

### DIFF
--- a/src/scraparr/connectors/__init__.py
+++ b/src/scraparr/connectors/__init__.py
@@ -53,7 +53,7 @@ class Connectors:
         next_run = {}
         for service, conns in self.connectors.items():
             for i, conn in enumerate(conns):
-                next_run[(service, i)] = time.time() + conn.interval
+                next_run[(service, i)] = time.time()
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=self.workers) as executor:
             while True:


### PR DESCRIPTION
This pull request makes a small change to the scheduling logic in the `scrape` method, affecting how connector jobs are initialized.

* The initial run time for each connector is now set to the current time (`time.time()`), ensuring that all connectors are executed immediately when the `scrape` method starts, instead of waiting for their configured interval before the first run.