### PR TITLE
fix(radarr): eliminate N+1 API queries in get_movies()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,15 @@ readme = "README.md"
 requires-python = ">=3.12"
 dynamic = ["dependencies"]
 
+[project.optional-dependencies]
+dev = ["pytest>=7.0.0", "pytest-cov>=4.0.0"]
+
 [project.scripts]
 scraparr = "scraparr.scraparr:main"
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["src/scraparr/requirements.txt"]}
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]

--- a/src/scraparr/connectors/radarr.py
+++ b/src/scraparr/connectors/radarr.py
@@ -21,13 +21,27 @@ def get_movies(url, api_key, version, alias):
         UP.labels(alias, 'radarr').set(0)
     else:
         for movie in res:
-            movie_file = util.get(f"{url}/api/{version}/moviefile?movieId={movie['id']}", api_key)
-            movie["movieFile"] = movie_file
+            movie["movieFile"] = _normalize_movie_file(movie, url, api_key, version)
 
         UP.labels(alias, 'radarr').set(1)
         radarr_metrics.LAST_SCRAPE.labels(alias).set(end_time)
         radarr_metrics.SCRAPE_DURATION.labels(alias).set(end_time - initial_time)
     return res
+
+
+def _normalize_movie_file(movie, url, api_key, version):
+    """Normalize movieFile to list format, using embedded data when possible."""
+    movie_file_count = movie.get('statistics', {}).get('movieFileCount', 0)
+
+    if movie_file_count == 0:
+        return []
+
+    if movie_file_count > 1:
+        return util.get(f"{url}/api/{version}/moviefile?movieId={movie['id']}", api_key)
+
+    embedded_file = movie.get('movieFile')
+    return [embedded_file] if embedded_file else []
+
 
 def analyse_movies(movies, detailed, alias):
     """Analyse the Movies and set the Correct Metrics"""

--- a/tests/test_radarr.py
+++ b/tests/test_radarr.py
@@ -1,0 +1,42 @@
+"""Tests for the N+1 query fix in radarr connector."""
+
+from unittest.mock import patch
+
+from scraparr.connectors.radarr import _normalize_movie_file
+
+
+class TestNormalizeMovieFile:
+
+    def test_no_file_returns_empty_list(self):
+        """Movies without files return empty list."""
+        movie = {'id': 1, 'hasFile': False, 'statistics': {'movieFileCount': 0}}
+        assert _normalize_movie_file(movie, 'http://test', 'key', 'v3') == []
+
+    def test_single_file_wraps_in_list(self):
+        """Single-file movies use embedded data, wrapped in list."""
+        embedded = {'quality': {'quality': {'name': 'Bluray-1080p'}}}
+        movie = {
+            'id': 1,
+            'hasFile': True,
+            'statistics': {'movieFileCount': 1},
+            'movieFile': embedded
+        }
+        result = _normalize_movie_file(movie, 'http://test', 'key', 'v3')
+        assert result == [embedded]
+
+    @patch('scraparr.connectors.radarr.util.get')
+    def test_multi_file_falls_back_to_api(self, mock_get):
+        """Multi-file movies make API call."""
+        mock_get.return_value = [{'id': 100}, {'id': 101}]
+        movie = {'id': 1, 'hasFile': True, 'statistics': {'movieFileCount': 2}}
+
+        result = _normalize_movie_file(movie, 'http://test', 'key', 'v3')
+
+        mock_get.assert_called_once_with('http://test/api/v3/moviefile?movieId=1', 'key')
+        assert result == [{'id': 100}, {'id': 101}]
+
+    def test_missing_movie_file_key_returns_empty(self):
+        """Defensive: missing movieFile key returns empty list."""
+        movie = {'id': 1, 'statistics': {'movieFileCount': 1}}
+        result = _normalize_movie_file(movie, 'http://test', 'key', 'v3')
+        assert result == []


### PR DESCRIPTION
## Problem

`get_movies()` makes an API call per movie to fetch `movieFile` data, even though `/api/v3/movie` already includes it embedded. This causes N unnecessary API calls per scrape (where N = number of movies).

Found while investigating abnormally high CPU usage on Traefik reverse proxy in front of Radarr.

## Solution

Use the embedded `movieFile` data directly instead of re-fetching it:

- Wrap embedded `movieFile` in a list (maintains compatibility with `increase_quality_count()`)
- Fall back to API only for multi-file movies (rare edge case)
- No data loss: single-file, no-file, and multi-file cases all handled

## Impact

Tested on my system with ~5700 movies:

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| API Requests | 5,786 /moviefile calls | 5 bulk API calls | 1,157x fewer |
| Scrape Duration | ~144 seconds | ~2.6 seconds | 55x faster |

## Testing

I've run this fork locally without issues - seems to be working as intended

🤖 Generated with [Claude Code](https://claude.ai/code)