### PR TITLE
fix(radarr): remove redundant per-movie API calls

### DIFF
--- a/src/scraparr/connectors/radarr.py
+++ b/src/scraparr/connectors/radarr.py
@@ -21,8 +21,11 @@ def get_movies(url, api_key, version, alias):
         UP.labels(alias, 'radarr').set(0)
     else:
         for movie in res:
-            movie_file = util.get(f"{url}/api/{version}/moviefile?movieId={movie['id']}", api_key)
-            movie["movieFile"] = movie_file
+            movie_file = movie.get("movieFile")
+            if movie_file and isinstance(movie_file, dict):
+                movie["movieFile"] = [movie_file]
+            elif not movie_file:
+                movie["movieFile"] = []
 
         UP.labels(alias, 'radarr').set(1)
         radarr_metrics.LAST_SCRAPE.labels(alias).set(end_time)


### PR DESCRIPTION
# Context

I noticed that some workers occasionally died, since scraping stopped, in most cases, radarr and sonarr. After digging
a bit deeper the likely cause is because radarr had to handle a lot of API requests (large library), and couldn't keep up.  If unlucky, it may cause an exception, and since the threading code doesn't have exception handling, the thread is killed and not restarted until scraparr itself has been restarted.

# Change

Radarr's /api/v3/movie endpoint already includes movieFile data for each title. Removed the unnecessary /api/v3/moviefile?movieId={id} calls that were fetching duplicate data.

Reduces scrape time from ~32s to ~0.5s for 640 titles (1 vs 641 calls).

To keep compatibility with existing utiltity functions, movieFile is converted from dict to list.

This change also reduce CPU usage of scraparr which can be seen below (blue before change, green after change).

<img width="383" height="174" alt="Screenshot 2026-01-22 at 20 50 16" src="https://github.com/user-attachments/assets/64d6406c-796d-4a0c-8ec0-eb6efba1c016" />
