### PR TITLE
fix(radarr): eliminate N+1 API queries in get_movies()

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,19 @@ scraparr = "scraparr.scraparr:main"
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["src/scraparr/requirements.txt"]}
+
+[tool.uv]
+package = true
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.pytest.ini_options]
+pythonpath = ["src"]
+testpaths = ["tests"]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-mock>=3.12.0",
+]

--- a/src/scraparr/connectors/radarr.py
+++ b/src/scraparr/connectors/radarr.py
@@ -24,6 +24,19 @@ class Module(ConnectorModule):
         radarr_metrics.MOVIE_MONITORED.remove_by_labels({"alias": self.alias})
         radarr_metrics.MOVIE_MISSING.remove_by_labels({"alias": self.alias})
 
+    def _normalize_movie_file(self, movie):
+        """Normalize movieFile to list format, using embedded data when possible."""
+        movie_file_count = movie.get('statistics', {}).get('movieFileCount', 0)
+
+        if movie_file_count == 0:
+            return []
+
+        if movie_file_count > 1:
+            return self.get(f"/moviefile?movieId={movie['id']}")
+
+        embedded_file = movie.get('movieFile')
+        return [embedded_file] if embedded_file else []
+
     def get_movies(self):
         """Grab the Movies from the Radarr Endpoint"""
 
@@ -33,8 +46,7 @@ class Module(ConnectorModule):
             UP.labels(self.alias, 'radarr').set(0)
         else:
             for movie in res:
-                movie_file = self.get(f"/moviefile?movieId={movie['id']}")
-                movie["movieFile"] = movie_file
+                movie["movieFile"] = self._normalize_movie_file(movie)
 
             UP.labels(self.alias, 'radarr').set(1)
         return res

--- a/tests/test_radarr.py
+++ b/tests/test_radarr.py
@@ -1,0 +1,53 @@
+"""Tests for the N+1 query fix in radarr connector."""
+
+from unittest.mock import patch, MagicMock
+
+from scraparr.connectors.radarr import Module
+
+
+class TestNormalizeMovieFile:
+
+    def setup_method(self):
+        """Create a Module instance for testing."""
+        config = {
+            'url': 'http://test',
+            'api_key': 'key',
+            'api_version': 'v3',
+            'alias': 'test_radarr',
+            'detailed': False
+        }
+        self.module = Module(config)
+
+    def test_no_file_returns_empty_list(self):
+        """Movies without files return empty list."""
+        movie = {'id': 1, 'hasFile': False, 'statistics': {'movieFileCount': 0}}
+        assert self.module._normalize_movie_file(movie) == []
+
+    def test_single_file_wraps_in_list(self):
+        """Single-file movies use embedded data, wrapped in list."""
+        embedded = {'quality': {'quality': {'name': 'Bluray-1080p'}}}
+        movie = {
+            'id': 1,
+            'hasFile': True,
+            'statistics': {'movieFileCount': 1},
+            'movieFile': embedded
+        }
+        result = self.module._normalize_movie_file(movie)
+        assert result == [embedded]
+
+    @patch.object(Module, 'get')
+    def test_multi_file_falls_back_to_api(self, mock_get):
+        """Multi-file movies make API call."""
+        mock_get.return_value = [{'id': 100}, {'id': 101}]
+        movie = {'id': 1, 'hasFile': True, 'statistics': {'movieFileCount': 2}}
+
+        result = self.module._normalize_movie_file(movie)
+
+        mock_get.assert_called_once_with('/moviefile?movieId=1')
+        assert result == [{'id': 100}, {'id': 101}]
+
+    def test_missing_movie_file_key_returns_empty(self):
+        """Defensive: missing movieFile key returns empty list."""
+        movie = {'id': 1, 'statistics': {'movieFileCount': 1}}
+        result = self.module._normalize_movie_file(movie)
+        assert result == []


### PR DESCRIPTION
## Problem

`get_movies()` makes an API call per movie to fetch `movieFile` data, even though `/api/v3/movie` already includes it embedded. This causes N unnecessary API calls per scrape (where N = number of movies).

Found while investigating abnormally high CPU usage on Traefik reverse proxy in front of Radarr.

## Solution

Use the embedded `movieFile` data directly instead of re-fetching it:

- Wrap embedded `movieFile` in a list (maintains compatibility with `increase_quality_count()`)
- Fall back to API only for multi-file movies (rare edge case)
- No data loss: single-file, no-file, and multi-file cases all handled

## Impact

Tested on my system with ~5700 movies:

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| API Requests | 5,786 /moviefile calls | 5 bulk API calls | 1,157x fewer |
| Scrape Duration | ~144 seconds | ~2.6 seconds | 55x faster |

## Testing

- 4 unit tests added for `_normalize_movie_file()`
- Also run locally without issues

🤖 Generated with [Claude Code](https://claude.ai/code)