### PR TITLE
feat: add environment variable substitution in config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,31 @@
+# =============================================================================
+# Scraparr Configuration
+# =============================================================================
+#
+# Environment Variable Substitution:
+# You can use ${VAR_NAME} syntax to reference environment variables.
+# This allows keeping secrets out of your config file.
+#
+# Supported syntax:
+#   ${VAR_NAME}           - Required env var (fails if not set)
+#   ${VAR_NAME:-default}  - Optional env var with fallback default
+#
+# Examples:
+#   api_key: ${SONARR_API_KEY}
+#   url: http://${HOST:-localhost}:${PORT:-8989}
+#
+# Docker Compose usage:
+#   environment:
+#     - SONARR_API_KEY=your-secret-key
+#   Or use env_file:
+#     env_file:
+#       - .env  # Contains SONARR_API_KEY=xxx
+#
+# Kubernetes usage:
+#   Mount secrets as environment variables using envFrom/secretRef
+#
+# =============================================================================
+
 general:
   # Exporter Listening Address and Port
   # address: 0.0.0.0 # Optional
@@ -14,7 +42,7 @@ auth:
 
 sonarr:
   url: http://sonarr:8989
-  api_key: key
+  api_key: key  # Or use: ${SONARR_API_KEY}
   # alias: sonarr # Optional to Differentiate between multiple Services
   # api_version: v3 # Optional to use a different API Version
   # interval: 30 # Optional to set a different Interval in Seconds
@@ -22,7 +50,7 @@ sonarr:
 
 radarr:
   url: http://radarr:7878
-  api_key: key
+  api_key: key  # Or use: ${RADARR_API_KEY}
   # alias: radarr # Optional to Differentiate between multiple Services
   # api_version: v3 # Optional to use a different API Version
   # interval: 30 # Optional to set a different Interval in Seconds
@@ -30,7 +58,7 @@ radarr:
 
 prowlarr:
   url: http://prowlarr:9696
-  api_key: key
+  api_key: key  # Or use: ${PROWLARR_API_KEY}
   # alias: prowlarr # Optional to Differentiate between multiple Services
   # api_version: v1 # Optional to use a different API Version
   # interval: 30 # Optional to set a different Interval in Seconds
@@ -38,14 +66,14 @@ prowlarr:
 
 bazarr:
   url: http://bazarr:6767
-  api_key: key
+  api_key: key  # Or use: ${BAZARR_API_KEY}
   # alias: bazarr # Optional to Differentiate between multiple Services
   # interval: 30 # Optional to set a different Interval in Seconds
   # detailed: true  # Get Data per Series
 
 readarr:
   url: http://readarr:8787
-  api_key: key
+  api_key: key  # Or use: ${READARR_API_KEY}
   # alias: prowlarr # Optional to Differentiate between multiple Services
   # api_version: v1 # Optional to use a different API Version
   # interval: 30 # Optional to set a different Interval in Seconds
@@ -53,28 +81,28 @@ readarr:
 
 jellyseerr:
   url: http://jellyseerr:5055
-  api_key: key
+  api_key: key  # Or use: ${JELLYSEERR_API_KEY}
   # alias: jellyseerr # Optional to Differentiate between multiple Services
   # interval: 30 # Optional to set a different Interval in Seconds
   # detailed: true  # Get Data per Request/Issue
 
 overseerr:
   url: http://overseerr:5055
-  api_key: key
+  api_key: key  # Or use: ${OVERSEERR_API_KEY}
   # alias: overseerr # Optional to Differentiate between multiple Services
   # interval: 30 # Optional to set a different Interval in Seconds
   # detailed: true  # Get Data per Request/Issue
 
 whisparr:
   url: http://whisparr:6969
-  api_key: key
+  api_key: key  # Or use: ${WHISPARR_API_KEY}
   # alias: whisparr # Optional to Differentiate between multiple Services
   # interval: 30 # Optional to set a different Interval in Seconds
   # detailed: true  # Get Data per Performer/Scene
 
 lidarr:
   url: http://lidarr:8096
-  api_key: key
+  api_key: key  # Or use: ${LIDARR_API_KEY}
   # alias: lidarr # Optional to Differentiate between multiple Services
   # interval: 30 # Optional to set a different Interval in Seconds
   # within: 30 # Optional to set a timeframe in seconds to search for sessions (default: 300)
@@ -82,7 +110,7 @@ lidarr:
 
 jellyfin:
   url: http://jellyfin:8096
-  api_key: key
+  api_key: key  # Or use: ${JELLYFIN_API_KEY}
   # alias: jellyfin # Optional to Differentiate between multiple Services
   # interval: 30 # Optional to set a different Interval in Seconds
   # within: 30 # Optional to set a timeframe in seconds to search for sessions (default: 300)

--- a/src/scraparr/config_loader.py
+++ b/src/scraparr/config_loader.py
@@ -1,0 +1,78 @@
+"""
+Config loading with environment variable substitution.
+
+Supports ${VAR_NAME} and ${VAR_NAME:-default} syntax in YAML string values.
+"""
+
+import logging
+import os
+import re
+from typing import Any
+
+import yaml
+
+# Matches ${VAR_NAME} or ${VAR_NAME:-default}
+ENV_VAR_PATTERN = re.compile(r'\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}')
+
+
+class MissingEnvVarError(Exception):
+    """Raised when a required environment variable is not set."""
+
+    def __init__(self, var_name: str, config_path: str = ""):
+        self.var_name = var_name
+        self.config_path = config_path
+        if config_path:
+            message = f"Environment variable '{var_name}' is not set (in config: {config_path})"
+        else:
+            message = f"Environment variable '{var_name}' is not set"
+        super().__init__(message)
+
+
+def _substitute_string(value: str, config_path: str) -> str:
+    """Substitute ${VAR} patterns in a string."""
+    def replacer(match: re.Match) -> str:
+        var_name = match.group(1)
+        default_value = match.group(2)
+
+        env_value = os.environ.get(var_name)
+        if env_value is not None:
+            return env_value
+
+        if default_value is not None:
+            logging.debug("Env var '%s' not set, using default (config: %s)", var_name, config_path)
+            return default_value
+
+        raise MissingEnvVarError(var_name, config_path)
+
+    return ENV_VAR_PATTERN.sub(replacer, value)
+
+
+def substitute_env_vars(config: Any, _path: str = "") -> Any:
+    """Recursively substitute ${VAR} patterns in string values."""
+    if isinstance(config, dict):
+        return {
+            key: substitute_env_vars(value, f"{_path}.{key}" if _path else key)
+            for key, value in config.items()
+        }
+
+    if isinstance(config, list):
+        return [
+            substitute_env_vars(item, f"{_path}[{i}]")
+            for i, item in enumerate(config)
+        ]
+
+    if isinstance(config, str):
+        return _substitute_string(config, _path)
+
+    return config
+
+
+def load_yaml_config(file_path: str) -> dict:
+    """Load YAML config file with environment variable substitution."""
+    with open(file_path, 'r', encoding='utf-8') as f:
+        config = yaml.safe_load(f)
+
+    if config is None:
+        return {}
+
+    return substitute_env_vars(config)

--- a/src/scraparr/scraparr.py
+++ b/src/scraparr/scraparr.py
@@ -21,6 +21,7 @@ from scraparr.connectors import util
 from scraparr.middleware import Middleware
 import scraparr.connectors
 from scraparr.parser import parse_env_config
+from scraparr.config_loader import load_yaml_config, MissingEnvVarError
 
 from scraparr.const import ACTIVE_CONNECTORS, BEAUTIFUL_CONNECTORS
 
@@ -31,8 +32,7 @@ CONFIG_FILE_LOCATION = "/scraparr/config/config.yaml"
 config_file = None
 
 try:
-    with open(CONFIG_FILE_LOCATION, 'r', encoding='utf-8') as yaml_file:
-        config_file = yaml.safe_load(yaml_file)
+    config_file = load_yaml_config(CONFIG_FILE_LOCATION)
 except FileNotFoundError:
     logging.error(
     	"Configuration file not found: %s, will try to load from environment variables",
@@ -49,6 +49,9 @@ except PermissionError:
     sys.exit(1)
 except yaml.YAMLError as exc:
     logging.error("Error parsing YAML file: %s", exc)
+    sys.exit(1)
+except MissingEnvVarError as exc:
+    logging.error("Missing required environment variable in config: %s", exc)
     sys.exit(1)
 
 if not config_file:

--- a/tests/test_config_env_substitution.py
+++ b/tests/test_config_env_substitution.py
@@ -1,0 +1,170 @@
+"""Tests for environment variable substitution in config loading."""
+
+import os
+import tempfile
+
+import pytest
+import yaml
+from unittest.mock import patch
+
+from scraparr.config_loader import (
+    MissingEnvVarError,
+    substitute_env_vars,
+    load_yaml_config,
+)
+
+
+class TestSubstituteEnvVars:
+    """Test environment variable substitution."""
+
+    def test_simple_substitution(self):
+        """Substitute ${VAR} with env var value."""
+        with patch.dict(os.environ, {"API_KEY": "secret123"}):
+            result = substitute_env_vars({"api_key": "${API_KEY}"})
+            assert result == {"api_key": "secret123"}
+
+    def test_partial_substitution(self):
+        """Substitute multiple vars in one string."""
+        with patch.dict(os.environ, {"HOST": "localhost", "PORT": "8989"}):
+            result = substitute_env_vars({"url": "http://${HOST}:${PORT}/api"})
+            assert result == {"url": "http://localhost:8989/api"}
+
+    def test_default_value(self):
+        """Use default when env var not set."""
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("MISSING", None)
+            result = substitute_env_vars({"host": "${MISSING:-localhost}"})
+            assert result == {"host": "localhost"}
+
+    def test_env_var_overrides_default(self):
+        """Env var value takes precedence over default."""
+        with patch.dict(os.environ, {"HOST": "server.local"}):
+            result = substitute_env_vars({"host": "${HOST:-localhost}"})
+            assert result == {"host": "server.local"}
+
+    def test_missing_var_raises_error(self):
+        """Missing required env var raises MissingEnvVarError."""
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("REQUIRED", None)
+            with pytest.raises(MissingEnvVarError) as exc_info:
+                substitute_env_vars({"key": "${REQUIRED}"})
+            assert exc_info.value.var_name == "REQUIRED"
+            assert "key" in str(exc_info.value)
+
+    def test_nested_dict(self):
+        """Substitute in nested dicts."""
+        with patch.dict(os.environ, {"KEY": "secret"}):
+            config = {"sonarr": {"api_key": "${KEY}"}}
+            result = substitute_env_vars(config)
+            assert result["sonarr"]["api_key"] == "secret"
+
+    def test_list_values(self):
+        """Substitute in list values."""
+        with patch.dict(os.environ, {"VAR": "value"}):
+            result = substitute_env_vars({"items": ["${VAR}", "static"]})
+            assert result == {"items": ["value", "static"]}
+
+    @pytest.mark.parametrize("value,expected_type", [
+        (8989, int),
+        (1.5, float),
+        (True, bool),
+        (None, type(None)),
+    ])
+    def test_non_string_types_unchanged(self, value, expected_type):
+        """Non-string types pass through unchanged."""
+        result = substitute_env_vars({"key": value})
+        assert result["key"] == value
+        assert isinstance(result["key"], expected_type)
+
+    def test_string_without_pattern_unchanged(self):
+        """Plain strings without ${} pass through unchanged."""
+        result = substitute_env_vars({"url": "http://localhost:8989"})
+        assert result == {"url": "http://localhost:8989"}
+
+    def test_dollar_without_braces_unchanged(self):
+        """$VAR without braces is NOT substituted."""
+        result = substitute_env_vars({"price": "$100"})
+        assert result == {"price": "$100"}
+
+
+class TestLoadYamlConfig:
+    """Test YAML config loading with env var substitution."""
+
+    def test_load_with_substitution(self):
+        """Load YAML and substitute env vars."""
+        with patch.dict(os.environ, {"SECRET": "mysecret"}):
+            with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+                f.write("api_key: ${SECRET}\n")
+                f.flush()
+                result = load_yaml_config(f.name)
+                os.unlink(f.name)
+            assert result == {"api_key": "mysecret"}
+
+    def test_load_empty_config(self):
+        """Empty config returns empty dict."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write("")
+            f.flush()
+            result = load_yaml_config(f.name)
+            os.unlink(f.name)
+        assert result == {}
+
+    def test_file_not_found(self):
+        """Raise FileNotFoundError for missing file."""
+        with pytest.raises(FileNotFoundError):
+            load_yaml_config("/nonexistent/config.yaml")
+
+    def test_invalid_yaml(self):
+        """Raise YAMLError for malformed YAML."""
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+            f.write("invalid: yaml: [")
+            f.flush()
+            with pytest.raises(yaml.YAMLError):
+                load_yaml_config(f.name)
+            os.unlink(f.name)
+
+    def test_missing_env_var_raises_error(self):
+        """Raise MissingEnvVarError for unset required var."""
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("REQUIRED", None)
+            with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
+                f.write("key: ${REQUIRED}\n")
+                f.flush()
+                with pytest.raises(MissingEnvVarError):
+                    load_yaml_config(f.name)
+                os.unlink(f.name)
+
+
+class TestBackwardsCompatibility:
+    """Ensure existing configs without env vars work unchanged."""
+
+    def test_config_without_env_vars(self):
+        """Config with hardcoded values works unchanged."""
+        config = {
+            "sonarr": {
+                "url": "http://sonarr:8989",
+                "api_key": "hardcoded_key",
+                "detailed": True,
+                "interval": 30
+            }
+        }
+        result = substitute_env_vars(config)
+        assert result == config
+
+    def test_mixed_hardcoded_and_env_vars(self):
+        """Mix of hardcoded and env var values."""
+        with patch.dict(os.environ, {"SONARR_KEY": "secret"}):
+            config = {
+                "sonarr": {
+                    "url": "http://sonarr:8989",
+                    "api_key": "${SONARR_KEY}"
+                },
+                "radarr": {
+                    "url": "http://radarr:7878",
+                    "api_key": "hardcoded"
+                }
+            }
+            result = substitute_env_vars(config)
+            assert result["sonarr"]["api_key"] == "secret"
+            assert result["radarr"]["api_key"] == "hardcoded"
+            assert result["sonarr"]["url"] == "http://sonarr:8989"


### PR DESCRIPTION
## Summary

Add support for environment variable substitution in `config.yaml` using `${VAR_NAME}` syntax, enabling secrets to be injected at runtime instead of hardcoded.

Closes #101

## Changes

- **New**: `src/scraparr/config_loader.py` - env var substitution module (78 lines)
- **New**: `tests/test_config_env_substitution.py` - 20 unit tests
- **Modified**: `src/scraparr/scraparr.py` - use new loader with `MissingEnvVarError` handling
- **Modified**: `config.yaml` - added usage documentation

## Supported Syntax

```yaml
api_key: ${SONARR_API_KEY}           # Required - fails if not set
api_key: ${SONARR_API_KEY:-default}  # Optional - uses default if not set
url: http://${HOST}:${PORT}/api      # Partial substitution
```

## Docker Compose Usage

```yaml
# docker-compose.yml
services:
  scraparr:
    image: ghcr.io/thecfu/scraparr:latest
    environment:
      - SONARR_API_KEY=${SONARR_API_KEY}
    env_file:
      - .env  # Contains SONARR_API_KEY=xxx (gitignored)
    volumes:
      - ./config.yaml:/scraparr/config/config.yaml:ro
```

```yaml
# config.yaml - safe to commit
sonarr:
  url: http://sonarr:8989
  api_key: ${SONARR_API_KEY}
```

## Kubernetes / Helm Usage

```yaml
# values.yaml - safe to commit (no secrets)
config:
  sonarr:
    url: http://sonarr:8989
    api_key: ${SONARR_API_KEY}

# Inject secrets via envFrom in deployment
extraEnvFrom:
  - secretRef:
      name: scraparr-secrets
```

**Note**: The Helm chart (`imgios/scraparr`) would need `extraEnv`/`extraEnvFrom` support added to the deployment template.

## Backwards Compatibility

**100% backwards compatible** - existing configs work unchanged:

| Pattern | Behavior |
|---------|----------|
| `api_key: hardcoded_value` | Unchanged (no `${...}` pattern) |
| `price: $100` | Unchanged (`$` without braces not substituted) |
| `port: 8989` | Unchanged (non-string types pass through) |
| `detailed: true` | Unchanged (booleans preserved as `bool`) |

The substitution only triggers on strings containing the exact `${VAR_NAME}` pattern.

🤖 Generated with [Claude Code](https://claude.ai/code)