### PR TITLE
feat: merge env vars on top of YAML config instead of fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,9 @@ A Unraid Template is available in the Repo of jordan-dalby: https://github.com/j
 Scraparr can be configured either by using a [config.yaml](config.yaml) file or by setting environment variables.  
 For environment variables, please refer to the [sample.env](sample.env) file. You can set them directly as environment options or create an `.env` file and import it using your container host.
 
-> [!IMPORTANT]
-> The environment variables don't support the configuration of Multiple Instances to use them you need to switch to the config
+> [!TIP]
+> Environment variables now support multiple instances using alias-based naming.
+> See [sample.env](sample.env) for examples.
 
 Make sure the configuration specifies the URLs and API keys for the *arr services you want to monitor.
 
@@ -127,6 +128,22 @@ sonarr:
     api_key: key
     alias: sonarr2
 ```
+
+#### Multiple Instances via Environment Variables
+
+You can also configure multiple instances using environment variables with alias-based naming:
+
+```bash
+# Main Sonarr instance
+SONARR_MAIN_URL=http://sonarr:8989
+SONARR_MAIN_API_KEY=main-key
+
+# Secondary Sonarr instance
+SONARR_SECONDARY_URL=http://sonarr2:8989
+SONARR_SECONDARY_API_KEY=secondary-key
+```
+
+The alias (e.g., `MAIN`, `SECONDARY`) becomes the instance identifier in metrics.
 
 ## Usage
 

--- a/sample.env
+++ b/sample.env
@@ -60,3 +60,16 @@ OVERSEERR_API_KEY=key
 # OVERSEERR_ALIAS=overseerr
 # OVERSEERR_INTERVAL=30
 # OVERSEERR_DETAILED=true
+
+# =============================================================================
+# Multiple Instances (alias-based)
+# =============================================================================
+# To configure multiple instances of the same service, use alias-based naming:
+#
+# SONARR_MAIN_URL=http://sonarr:8989
+# SONARR_MAIN_API_KEY=main-key
+# SONARR_SECONDARY_URL=http://sonarr2:8989
+# SONARR_SECONDARY_API_KEY=secondary-key
+#
+# Supported fields: URL, API_KEY, ALIAS, API_VERSION, INTERVAL, DETAILED, WITHIN
+# =============================================================================

--- a/sample.env
+++ b/sample.env
@@ -71,5 +71,4 @@ OVERSEERR_API_KEY=key
 # SONARR_SECONDARY_URL=http://sonarr2:8989
 # SONARR_SECONDARY_API_KEY=secondary-key
 #
-# Supported fields: URL, API_KEY, ALIAS, API_VERSION, INTERVAL, DETAILED, WITHIN
 # =============================================================================

--- a/src/scraparr/config_loader.py
+++ b/src/scraparr/config_loader.py
@@ -11,13 +11,10 @@ from typing import Any, List
 
 import yaml
 
+from scraparr.const import BOOL_FIELDS, INT_FIELDS
+
 # Matches ${VAR_NAME} or ${VAR_NAME:-default}
 ENV_VAR_PATTERN = re.compile(r'\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}')
-
-# Fields that should be integers
-INT_FIELDS = {'interval', 'within', 'port', 'workers'}
-# Fields that should be booleans
-BOOL_FIELDS = {'detailed'}
 
 
 class MissingEnvVarError(Exception):
@@ -195,3 +192,29 @@ def deep_merge(base: dict, override: dict) -> dict:
             result[key] = override_value
 
     return result
+
+
+def validate_service_config(service: str, config) -> list:
+    """Validate service config has required fields (url and api_key).
+
+    Args:
+        service: Service name (e.g., 'sonarr')
+        config: Service config - dict for single instance, list for multi-instance, or None
+
+    Returns:
+        List of error messages (empty if valid)
+    """
+    errors = []
+    if config is None:
+        return errors
+
+    configs = [config] if isinstance(config, dict) else config
+    for i, cfg in enumerate(configs):
+        if not isinstance(cfg, dict):
+            continue
+        alias = cfg.get('alias', f'instance {i}')
+        if not cfg.get('url'):
+            errors.append(f"{service} ({alias}): missing 'url'")
+        if not cfg.get('api_key'):
+            errors.append(f"{service} ({alias}): missing 'api_key'")
+    return errors

--- a/src/scraparr/config_loader.py
+++ b/src/scraparr/config_loader.py
@@ -7,12 +7,17 @@ Supports ${VAR_NAME} and ${VAR_NAME:-default} syntax in YAML string values.
 import logging
 import os
 import re
-from typing import Any
+from typing import Any, List
 
 import yaml
 
 # Matches ${VAR_NAME} or ${VAR_NAME:-default}
 ENV_VAR_PATTERN = re.compile(r'\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-([^}]*))?\}')
+
+# Fields that should be integers
+INT_FIELDS = {'interval', 'within', 'port', 'workers'}
+# Fields that should be booleans
+BOOL_FIELDS = {'detailed'}
 
 
 class MissingEnvVarError(Exception):
@@ -26,6 +31,22 @@ class MissingEnvVarError(Exception):
         else:
             message = f"Environment variable '{var_name}' is not set"
         super().__init__(message)
+
+
+def _parse_bool(value: str) -> bool:
+    """Parse boolean from string."""
+    return value.lower() in ('true', '1', 'yes')
+
+
+def _coerce_value(key: str, value: Any) -> Any:
+    """Coerce string values to appropriate types based on field name."""
+    if not isinstance(value, str):
+        return value
+    if key in INT_FIELDS:
+        return int(value)
+    if key in BOOL_FIELDS:
+        return _parse_bool(value)
+    return value
 
 
 def _substitute_string(value: str, config_path: str) -> str:
@@ -67,8 +88,25 @@ def substitute_env_vars(config: Any, _path: str = "") -> Any:
     return config
 
 
+def coerce_config_types(config: Any) -> Any:
+    """Recursively coerce string values to appropriate types based on field names."""
+    if isinstance(config, dict):
+        return {
+            key: _coerce_value(key, coerce_config_types(value))
+            for key, value in config.items()
+        }
+
+    if isinstance(config, list):
+        return [coerce_config_types(item) for item in config]
+
+    return config
+
+
 def load_yaml_config(file_path: str) -> dict:
-    """Load YAML config file with environment variable substitution."""
+    """Load YAML config file with environment variable substitution.
+
+    Note: Type coercion should be done after merging with env config.
+    """
     with open(file_path, 'r', encoding='utf-8') as f:
         config = yaml.safe_load(f)
 
@@ -76,3 +114,84 @@ def load_yaml_config(file_path: str) -> dict:
         return {}
 
     return substitute_env_vars(config)
+
+
+def load_yaml_config_safe(file_path: str) -> dict:
+    """Load YAML config, returning empty dict if file not found."""
+    try:
+        return load_yaml_config(file_path)
+    except FileNotFoundError:
+        return {}
+
+
+def _merge_list_by_alias(base_list: List[dict], aliases_dict: dict) -> List[dict]:
+    """Merge a list of configs (from YAML) with an alias-keyed dict (from env).
+
+    Matches items by 'alias' field and merges. New aliases are appended.
+    """
+    result = []
+    seen_aliases = set()
+
+    # Merge existing items
+    for item in base_list:
+        if isinstance(item, dict) and 'alias' in item:
+            alias = item['alias']
+            seen_aliases.add(alias)
+            if alias in aliases_dict:
+                # Merge env override into this item
+                result.append(deep_merge(item, aliases_dict[alias]))
+            else:
+                result.append(item)
+        else:
+            result.append(item)
+
+    # Add new instances from env that weren't in YAML
+    for alias, fields in aliases_dict.items():
+        if alias not in seen_aliases:
+            new_item = dict(fields)
+            new_item['alias'] = alias
+            result.append(new_item)
+
+    return result
+
+
+def deep_merge(base: dict, override: dict) -> dict:
+    """Deep merge dicts. Override values take priority. None = not set (preserves base).
+
+    Special handling for multi-instance configs:
+    - If override has '_aliases' key, it's a multi-instance env config
+    - If base is a list (multi-instance YAML), merge by alias
+    """
+    result = base.copy()
+
+    for key, override_value in override.items():
+        if override_value is None:
+            # None means "not set" in override, preserve base value
+            continue
+
+        # Check for multi-instance env config (has _aliases marker)
+        if isinstance(override_value, dict) and '_aliases' in override_value:
+            aliases_dict = override_value['_aliases']
+            if key in result and isinstance(result[key], list):
+                # YAML has list, env has aliases - merge by alias
+                result[key] = _merge_list_by_alias(result[key], aliases_dict)
+            elif key not in result or result[key] is None:
+                # No YAML config - convert aliases to list
+                result[key] = [
+                    {**fields, 'alias': alias}
+                    for alias, fields in aliases_dict.items()
+                ]
+            # else: YAML has single instance, env has multi - keep YAML (don't replace)
+            continue
+
+        if key in result and isinstance(result[key], dict) and isinstance(override_value, dict):
+            # Recursively merge nested dicts
+            result[key] = deep_merge(result[key], override_value)
+        elif key in result and isinstance(result[key], list):
+            # Base is list but override is not _aliases - preserve list
+            continue
+        else:
+            # Override takes priority
+            result[key] = override_value
+
+    return result

--- a/src/scraparr/const.py
+++ b/src/scraparr/const.py
@@ -19,8 +19,12 @@ API_VERSIONS = {
 
 BEAUTIFUL_CONNECTORS = ", ".join(ACTIVE_CONNECTORS[:-1]) + " or " + ACTIVE_CONNECTORS[-1]
 
-# Optional ENV variables for connectors
-OPTIONAL_FIELDS = [
-    'alias', 'api_version', 'interval',
-    'detailed', 'within', 'episode_quality_stats',
-]
+# Field names by type (for type coercion after env var parsing)
+INT_FIELDS = {'interval', 'within', 'port', 'workers'}
+BOOL_FIELDS = {'detailed', 'episode_quality_stats'}
+
+# Service-specific fields (for env var parsing - distinguishes SONARR_URL from SONARR_PROD_URL)
+SERVICE_FIELDS = {
+    'url', 'api_key', 'alias', 'api_version',
+    'interval', 'detailed', 'within', 'episode_quality_stats',
+}

--- a/src/scraparr/parser/__init__.py
+++ b/src/scraparr/parser/__init__.py
@@ -4,10 +4,7 @@ import os
 from typing import Any, Optional, Dict, Mapping
 from dotenv import dotenv_values
 
-from scraparr.const import ACTIVE_CONNECTORS
-
-# All known service field names (used to distinguish SONARR_URL from SONARR_PROD_URL)
-SERVICE_FIELDS = {'url', 'api_key', 'alias', 'api_version', 'interval', 'detailed', 'within'}
+from scraparr.const import ACTIVE_CONNECTORS, SERVICE_FIELDS
 
 
 def _parse_service_field(env_key: str, prefix: str) -> Optional[tuple]:

--- a/src/scraparr/parser/__init__.py
+++ b/src/scraparr/parser/__init__.py
@@ -1,46 +1,101 @@
 """Parses Scraparr configuration from environment or .env file."""
 
 import os
-import sys
-from typing import Optional, Dict, Mapping
+from typing import Any, Optional, Dict, Mapping
 from dotenv import dotenv_values
 
-from scraparr.const import ACTIVE_CONNECTORS, OPTIONAL_FIELDS
+from scraparr.const import ACTIVE_CONNECTORS
 
-def _build_config(env: Mapping[str, str]) -> Dict[str, Optional[Dict[str, str]]]:
-    config: Dict[str, Optional[Dict[str, str]]] = {
-        'general': None,
-        'auth': None,
+# All known service field names (used to distinguish SONARR_URL from SONARR_PROD_URL)
+SERVICE_FIELDS = {'url', 'api_key', 'alias', 'api_version', 'interval', 'detailed', 'within'}
+
+
+def _parse_service_field(env_key: str, prefix: str) -> Optional[tuple]:
+    """Parse env var to extract field name and optional alias.
+
+    Returns (field, alias) or None if not a valid service field.
+    - SONARR_URL -> ('url', None)
+    - SONARR_PROD_URL -> ('url', 'prod')
+    - SONARR_API_KEY -> ('api_key', None)
+    - SONARR_PROD_API_KEY -> ('api_key', 'prod')
+    """
+    if not env_key.startswith(prefix):
+        return None
+
+    remainder = env_key[len(prefix):]  # e.g., "URL", "PROD_URL", "API_KEY"
+
+    # Check each known field (longest first to match API_KEY before checking for _KEY suffix)
+    for field in sorted(SERVICE_FIELDS, key=len, reverse=True):
+        field_upper = field.upper()
+        if remainder == field_upper:
+            # Single instance: SONARR_URL
+            return (field, None)
+        if remainder.endswith(f'_{field_upper}'):
+            # Multi-instance: SONARR_PROD_URL
+            alias = remainder[:-len(f'_{field_upper}')]
+            if alias:  # Ensure alias is not empty
+                return (field, alias.lower())
+
+    return None
+
+
+def _parse_mapping(env: Mapping[str, str], mapping: Dict[str, str]) -> Optional[Dict[str, str]]:
+    """Parse env vars using a mapping of ENV_KEY -> config_key."""
+    return {k: env[p] for p, k in mapping.items() if p in env} or None
+
+
+def _build_config(env: Mapping[str, str]) -> Dict[str, Optional[Any]]:
+    config: Dict[str, Optional[Any]] = {
+        'general': _parse_mapping(env, {
+            'GENERAL_PATH': 'path',
+            'GENERAL_ADDRESS': 'address',
+            'GENERAL_PORT': 'port',
+            'GENERAL_WORKERS': 'workers',
+            'GENERAL_LOG_LEVEL': 'log_level',
+        }),
+        'auth': _parse_mapping(env, {
+            'AUTH_USERNAME': 'username',
+            'AUTH_PASSWORD': 'password',
+            'AUTH_TOKEN': 'token',
+        }),
     }
-    for service in ACTIVE_CONNECTORS:
-        try:
-            prefix = service.upper()
-            url = env.get(f'{prefix}_URL')
-            api_key = env.get(f'{prefix}_API_KEY')
 
-            if url and api_key:
-                service_config = {
-                    'url': url,
-                    'api_key': api_key,
-                    **{
-                        field: int(val) if field in {"interval", "within"} else val
-                        for field in OPTIONAL_FIELDS
-                        if (val := env.get(f'{prefix}_{field.upper()}')) is not None
-                    }
-                }
-                config[service] = service_config
+    for service in ACTIVE_CONNECTORS:
+        prefix = f'{service.upper()}_'
+        single_config: Dict[str, Any] = {}
+        multi_config: Dict[str, Dict[str, Any]] = {}  # alias -> fields
+
+        for env_key in env:
+            parsed = _parse_service_field(env_key, prefix)
+            if parsed is None:
+                continue
+
+            field, alias = parsed
+            value = env[env_key]  # Keep as string - type coercion after merge
+
+            if alias is None:
+                single_config[field] = value
             else:
-                config[service] = None
-        except ValueError as e:
-            print(f"Error parsing environment variables for {service}: {e}")
-            sys.exit(1)
+                if alias not in multi_config:
+                    multi_config[alias] = {}
+                multi_config[alias][field] = value
+
+        # Decide mode: multi-instance takes precedence if any alias vars exist
+        if multi_config:
+            config[service] = {'_aliases': multi_config}
+        elif single_config:
+            config[service] = single_config
+        else:
+            config[service] = None
 
     return config
 
-def parse_dotenv_config(path: str = "/scraparr/.env") -> Dict[str, Optional[Dict[str, str]]]:
+
+def parse_dotenv_config(path: str = ".env") -> Dict[str, Optional[Any]]:
     """Parse configuration from a .env file at the given path."""
     return _build_config(dotenv_values(path))  # type: ignore
 
-def parse_env_config() -> Dict[str, Optional[Dict[str, str]]]:
+
+def parse_env_config() -> Dict[str, Optional[Any]]:
     """Parse configuration from the current environment variables."""
     return _build_config(os.environ)

--- a/src/scraparr/scraparr.py
+++ b/src/scraparr/scraparr.py
@@ -23,7 +23,8 @@ from scraparr.middleware import Middleware
 import scraparr.connectors
 from scraparr.parser import parse_env_config
 from scraparr.config_loader import (
-    load_yaml_config_safe, deep_merge, coerce_config_types, MissingEnvVarError
+    load_yaml_config_safe, deep_merge, coerce_config_types, MissingEnvVarError,
+    validate_service_config
 )
 
 from scraparr.const import ACTIVE_CONNECTORS, BEAUTIFUL_CONNECTORS
@@ -43,6 +44,16 @@ try:
     env_config = parse_env_config()
     # Merge: YAML (base) <- environment variables (includes .env values)
     config_file = coerce_config_types(deep_merge(yaml_config, env_config))
+
+    # Validate required fields in merged config
+    validation_errors = []
+    for service in ACTIVE_CONNECTORS:
+        if service in config_file:
+            validation_errors.extend(validate_service_config(service, config_file[service]))
+    if validation_errors:
+        for error in validation_errors:
+            logging.error("Invalid config: %s", error)
+        sys.exit(1)
 except PermissionError:
     logging.error("Permission denied to read the configuration file: %s", CONFIG_FILE_LOCATION)
     sys.exit(1)

--- a/src/scraparr/scraparr.py
+++ b/src/scraparr/scraparr.py
@@ -47,9 +47,9 @@ try:
 
     # Validate required fields in merged config
     validation_errors = []
-    for service in ACTIVE_CONNECTORS:
-        if service in config_file:
-            validation_errors.extend(validate_service_config(service, config_file[service]))
+    for svc in ACTIVE_CONNECTORS:
+        if svc in config_file:
+            validation_errors.extend(validate_service_config(svc, config_file[svc]))
     if validation_errors:
         for error in validation_errors:
             logging.error("Invalid config: %s", error)

--- a/src/scraparr/scraparr.py
+++ b/src/scraparr/scraparr.py
@@ -15,35 +15,34 @@ import logging
 from wsgiref.simple_server import make_server
 
 import yaml
+from dotenv import load_dotenv
 from prometheus_client import make_wsgi_app
 
 from scraparr.connectors import util
 from scraparr.middleware import Middleware
 import scraparr.connectors
 from scraparr.parser import parse_env_config
-from scraparr.config_loader import load_yaml_config, MissingEnvVarError
+from scraparr.config_loader import (
+    load_yaml_config_safe, deep_merge, coerce_config_types, MissingEnvVarError
+)
 
 from scraparr.const import ACTIVE_CONNECTORS, BEAUTIFUL_CONNECTORS
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+# Load .env file into os.environ (if present) before parsing config
+# This allows ${VAR} in YAML to reference .env values
+load_dotenv()
 
 CONFIG_FILE_LOCATION = "/scraparr/config/config.yaml"
 
 config_file = None
 
 try:
-    config_file = load_yaml_config(CONFIG_FILE_LOCATION)
-except FileNotFoundError:
-    logging.error(
-    	"Configuration file not found: %s, will try to load from environment variables",
-    	CONFIG_FILE_LOCATION
-    )
-
-    config_file = parse_env_config()
-
-    if not config_file:
-        logging.error("No configuration found in environment variables.")
-        sys.exit(1)
+    yaml_config = load_yaml_config_safe(CONFIG_FILE_LOCATION)
+    env_config = parse_env_config()
+    # Merge: YAML (base) <- environment variables (includes .env values)
+    config_file = coerce_config_types(deep_merge(yaml_config, env_config))
 except PermissionError:
     logging.error("Permission denied to read the configuration file: %s", CONFIG_FILE_LOCATION)
     sys.exit(1)
@@ -53,18 +52,21 @@ except yaml.YAMLError as exc:
 except MissingEnvVarError as exc:
     logging.error("Missing required environment variable in config: %s", exc)
     sys.exit(1)
+except ValueError as exc:
+    logging.error("Invalid config value: %s", exc)
+    sys.exit(1)
 
 if not config_file:
     logging.error("Configuration is empty. Please provide a valid configuration.")
     sys.exit(1)
 
-GENERAL = config_file.get('GENERAL', {})
+GENERAL = config_file.get('general', {})
 PATH = GENERAL.get('path', "/metrics")
 ADDRESS = GENERAL.get('address', "0.0.0.0")
 PORT = int(GENERAL.get('port', 7100))
 WORKERS = GENERAL.get('workers', 5)
 
-AUTH = config_file.get('AUTH', {})
+AUTH = config_file.get('auth', {})
 USERNAME = AUTH.get('username', None)
 PASSWORD = AUTH.get('password', None)
 BEARER_TOKEN = AUTH.get('token', None)

--- a/tests/test_config_env_substitution.py
+++ b/tests/test_config_env_substitution.py
@@ -10,7 +10,10 @@ from unittest.mock import patch
 from scraparr.config_loader import (
     MissingEnvVarError,
     substitute_env_vars,
+    coerce_config_types,
     load_yaml_config,
+    load_yaml_config_safe,
+    deep_merge,
 )
 
 
@@ -23,16 +26,15 @@ class TestSubstituteEnvVars:
             result = substitute_env_vars({"api_key": "${API_KEY}"})
             assert result == {"api_key": "secret123"}
 
-    def test_partial_substitution(self):
+    def test_multiple_vars_in_string(self):
         """Substitute multiple vars in one string."""
         with patch.dict(os.environ, {"HOST": "localhost", "PORT": "8989"}):
             result = substitute_env_vars({"url": "http://${HOST}:${PORT}/api"})
             assert result == {"url": "http://localhost:8989/api"}
 
-    def test_default_value(self):
+    def test_default_value_when_missing(self):
         """Use default when env var not set."""
         with patch.dict(os.environ, {}, clear=True):
-            os.environ.pop("MISSING", None)
             result = substitute_env_vars({"host": "${MISSING:-localhost}"})
             assert result == {"host": "localhost"}
 
@@ -42,44 +44,29 @@ class TestSubstituteEnvVars:
             result = substitute_env_vars({"host": "${HOST:-localhost}"})
             assert result == {"host": "server.local"}
 
-    def test_missing_var_raises_error(self):
+    def test_missing_required_var_raises_error(self):
         """Missing required env var raises MissingEnvVarError."""
         with patch.dict(os.environ, {}, clear=True):
-            os.environ.pop("REQUIRED", None)
             with pytest.raises(MissingEnvVarError) as exc_info:
                 substitute_env_vars({"key": "${REQUIRED}"})
             assert exc_info.value.var_name == "REQUIRED"
-            assert "key" in str(exc_info.value)
 
-    def test_nested_dict(self):
-        """Substitute in nested dicts."""
-        with patch.dict(os.environ, {"KEY": "secret"}):
-            config = {"sonarr": {"api_key": "${KEY}"}}
+    def test_nested_dict_and_list(self):
+        """Substitute in nested dicts and lists."""
+        with patch.dict(os.environ, {"KEY": "secret", "VAL": "item"}):
+            config = {"service": {"api_key": "${KEY}"}, "items": ["${VAL}", "static"]}
             result = substitute_env_vars(config)
-            assert result["sonarr"]["api_key"] == "secret"
-
-    def test_list_values(self):
-        """Substitute in list values."""
-        with patch.dict(os.environ, {"VAR": "value"}):
-            result = substitute_env_vars({"items": ["${VAR}", "static"]})
-            assert result == {"items": ["value", "static"]}
+            assert result["service"]["api_key"] == "secret"
+            assert result["items"] == ["item", "static"]
 
     @pytest.mark.parametrize("value,expected_type", [
-        (8989, int),
-        (1.5, float),
-        (True, bool),
-        (None, type(None)),
+        (8989, int), (1.5, float), (True, bool), (None, type(None)),
     ])
     def test_non_string_types_unchanged(self, value, expected_type):
         """Non-string types pass through unchanged."""
         result = substitute_env_vars({"key": value})
         assert result["key"] == value
         assert isinstance(result["key"], expected_type)
-
-    def test_string_without_pattern_unchanged(self):
-        """Plain strings without ${} pass through unchanged."""
-        result = substitute_env_vars({"url": "http://localhost:8989"})
-        assert result == {"url": "http://localhost:8989"}
 
     def test_dollar_without_braces_unchanged(self):
         """$VAR without braces is NOT substituted."""
@@ -88,7 +75,7 @@ class TestSubstituteEnvVars:
 
 
 class TestLoadYamlConfig:
-    """Test YAML config loading with env var substitution."""
+    """Test YAML config loading."""
 
     def test_load_with_substitution(self):
         """Load YAML and substitute env vars."""
@@ -100,7 +87,7 @@ class TestLoadYamlConfig:
                 os.unlink(f.name)
             assert result == {"api_key": "mysecret"}
 
-    def test_load_empty_config(self):
+    def test_empty_config_returns_empty_dict(self):
         """Empty config returns empty dict."""
         with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
             f.write("")
@@ -109,12 +96,12 @@ class TestLoadYamlConfig:
             os.unlink(f.name)
         assert result == {}
 
-    def test_file_not_found(self):
+    def test_file_not_found_raises(self):
         """Raise FileNotFoundError for missing file."""
         with pytest.raises(FileNotFoundError):
             load_yaml_config("/nonexistent/config.yaml")
 
-    def test_invalid_yaml(self):
+    def test_invalid_yaml_raises(self):
         """Raise YAMLError for malformed YAML."""
         with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
             f.write("invalid: yaml: [")
@@ -123,48 +110,226 @@ class TestLoadYamlConfig:
                 load_yaml_config(f.name)
             os.unlink(f.name)
 
-    def test_missing_env_var_raises_error(self):
-        """Raise MissingEnvVarError for unset required var."""
-        with patch.dict(os.environ, {}, clear=True):
-            os.environ.pop("REQUIRED", None)
-            with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
-                f.write("key: ${REQUIRED}\n")
-                f.flush()
-                with pytest.raises(MissingEnvVarError):
-                    load_yaml_config(f.name)
-                os.unlink(f.name)
+    def test_safe_returns_empty_on_missing(self):
+        """load_yaml_config_safe returns empty dict when file not found."""
+        result = load_yaml_config_safe("/nonexistent/config.yaml")
+        assert result == {}
 
 
-class TestBackwardsCompatibility:
-    """Ensure existing configs without env vars work unchanged."""
+class TestDeepMerge:
+    """Test deep_merge function."""
 
-    def test_config_without_env_vars(self):
-        """Config with hardcoded values works unchanged."""
+    def test_override_wins(self):
+        """Override values take priority over base."""
+        base = {"a": 1, "b": 2}
+        override = {"b": 3, "c": 4}
+        result = deep_merge(base, override)
+        assert result == {"a": 1, "b": 3, "c": 4}
+
+    def test_nested_merge(self):
+        """Recursively merge nested dicts, override wins."""
+        base = {"sonarr": {"url": "http://old", "api_key": "key1"}}
+        override = {"sonarr": {"url": "http://new"}}
+        result = deep_merge(base, override)
+        assert result == {"sonarr": {"url": "http://new", "api_key": "key1"}}
+
+    def test_none_preserves_base(self):
+        """None in override means 'not set', preserves base value."""
+        base = {"sonarr": {"url": "http://localhost", "api_key": "key"}}
+        override = {"sonarr": None, "radarr": {"url": "http://radarr"}}
+        result = deep_merge(base, override)
+        assert result["sonarr"] == {"url": "http://localhost", "api_key": "key"}
+        assert result["radarr"] == {"url": "http://radarr"}
+
+
+class TestTypeCoercion:
+    """Test type conversion for int/bool fields."""
+
+    def test_int_fields_coerced(self):
+        """Integer fields (interval, port, workers, within) are coerced."""
         config = {
-            "sonarr": {
-                "url": "http://sonarr:8989",
-                "api_key": "hardcoded_key",
-                "detailed": True,
-                "interval": 30
-            }
+            'sonarr': {'interval': '30', 'within': '7'},
+            'general': {'port': '8080', 'workers': '4'}
         }
-        result = substitute_env_vars(config)
-        assert result == config
+        result = coerce_config_types(config)
+        assert result['sonarr']['interval'] == 30
+        assert result['sonarr']['within'] == 7
+        assert result['general']['port'] == 8080
+        assert result['general']['workers'] == 4
 
-    def test_mixed_hardcoded_and_env_vars(self):
-        """Mix of hardcoded and env var values."""
-        with patch.dict(os.environ, {"SONARR_KEY": "secret"}):
-            config = {
-                "sonarr": {
-                    "url": "http://sonarr:8989",
-                    "api_key": "${SONARR_KEY}"
-                },
-                "radarr": {
-                    "url": "http://radarr:7878",
-                    "api_key": "hardcoded"
-                }
-            }
-            result = substitute_env_vars(config)
-            assert result["sonarr"]["api_key"] == "secret"
-            assert result["radarr"]["api_key"] == "hardcoded"
-            assert result["sonarr"]["url"] == "http://sonarr:8989"
+    @pytest.mark.parametrize("value,expected", [
+        ('true', True), ('True', True), ('TRUE', True),
+        ('yes', True), ('1', True),
+        ('false', False), ('False', False), ('FALSE', False),
+        ('no', False), ('0', False), ('anything', False),
+    ])
+    def test_bool_field_coerced(self, value, expected):
+        """Boolean field 'detailed' is coerced from various string values."""
+        config = {'sonarr': {'detailed': value}}
+        result = coerce_config_types(config)
+        assert result['sonarr']['detailed'] is expected
+
+    def test_non_coercible_fields_unchanged(self):
+        """Fields not in INT_FIELDS/BOOL_FIELDS stay as strings."""
+        config = {'sonarr': {'url': 'http://test', 'api_key': 'secret'}}
+        result = coerce_config_types(config)
+        assert result['sonarr']['url'] == 'http://test'
+        assert result['sonarr']['api_key'] == 'secret'
+
+    def test_already_typed_values_unchanged(self):
+        """Values that are already int/bool pass through unchanged."""
+        config = {'sonarr': {'interval': 30, 'detailed': True}}
+        result = coerce_config_types(config)
+        assert result['sonarr']['interval'] == 30
+        assert result['sonarr']['detailed'] is True
+
+
+class TestEnvVarParsing:
+    """Test environment variable parsing."""
+
+    @pytest.mark.parametrize("env_key,prefix,expected", [
+        ('SONARR_URL', 'SONARR_', ('url', None)),
+        ('SONARR_API_KEY', 'SONARR_', ('api_key', None)),
+        ('SONARR_PROD_URL', 'SONARR_', ('url', 'prod')),
+        ('SONARR_PROD_API_KEY', 'SONARR_', ('api_key', 'prod')),
+        ('SONARR_MY_PROD_URL', 'SONARR_', ('url', 'my_prod')),
+        ('SONARR_FOOBAR', 'SONARR_', None),
+        ('RADARR_URL', 'SONARR_', None),
+    ])
+    def test_parse_service_field(self, env_key, prefix, expected):
+        """Parse env var to extract field name and optional alias."""
+        from scraparr.parser import _parse_service_field
+        assert _parse_service_field(env_key, prefix) == expected
+
+    def test_parse_general_and_auth(self):
+        """Parse general and auth fields from env vars."""
+        from scraparr.parser import _parse_mapping
+        general = _parse_mapping(
+            {'GENERAL_PORT': '8080', 'GENERAL_LOG_LEVEL': 'DEBUG'},
+            {'GENERAL_PORT': 'port', 'GENERAL_LOG_LEVEL': 'log_level'}
+        )
+        assert general == {'port': '8080', 'log_level': 'DEBUG'}
+        assert _parse_mapping({}, {'GENERAL_PORT': 'port'}) is None
+
+        auth = _parse_mapping(
+            {'AUTH_USERNAME': 'admin', 'AUTH_TOKEN': 'secret'},
+            {'AUTH_USERNAME': 'username', 'AUTH_TOKEN': 'token'}
+        )
+        assert auth == {'username': 'admin', 'token': 'secret'}
+
+
+class TestConfigMergeIntegration:
+    """Integration tests for YAML + env var merge behavior."""
+
+    def test_partial_env_override(self):
+        """Env var overrides single field while YAML provides the rest."""
+        from scraparr.parser import parse_env_config
+        with patch.dict(os.environ, {'SONARR_URL': 'http://override:8989'}, clear=True):
+            env_config = parse_env_config()
+            assert env_config['sonarr'] == {'url': 'http://override:8989'}
+
+        yaml_config = {'sonarr': {'url': 'http://yaml:8989', 'api_key': 'yaml-key'}}
+        result = deep_merge(yaml_config, env_config)
+        assert result['sonarr']['url'] == 'http://override:8989'
+        assert result['sonarr']['api_key'] == 'yaml-key'
+
+    def test_general_partial_override_with_coercion(self):
+        """GENERAL_PORT env var overrides and gets coerced to int."""
+        from scraparr.parser import parse_env_config
+        with patch.dict(os.environ, {'GENERAL_PORT': '8080'}, clear=True):
+            env_config = parse_env_config()
+
+        yaml_config = {'general': {'port': 7100, 'workers': 5}}
+        result = coerce_config_types(deep_merge(yaml_config, env_config))
+        assert result['general']['port'] == 8080
+        assert result['general']['workers'] == 5
+
+    def test_add_service_via_env(self):
+        """Add new service via env while keeping existing YAML services."""
+        from scraparr.parser import parse_env_config
+        with patch.dict(os.environ, {
+            'RADARR_URL': 'http://radarr:7878',
+            'RADARR_API_KEY': 'radarr-key',
+        }, clear=True):
+            env_config = parse_env_config()
+
+        yaml_config = {'sonarr': {'url': 'http://sonarr:8989', 'api_key': 'sonarr-key'}}
+        result = deep_merge(yaml_config, env_config)
+        assert result['sonarr']['api_key'] == 'sonarr-key'
+        assert result['radarr']['api_key'] == 'radarr-key'
+
+
+class TestMultiInstanceAliasEnvVars:
+    """Test multi-instance alias-based env vars."""
+
+    def test_parse_alias_env_vars(self):
+        """Parse SONARR_PROD_URL as alias 'prod'."""
+        from scraparr.parser import parse_env_config
+        with patch.dict(os.environ, {
+            'SONARR_PROD_URL': 'http://prod:8989',
+            'SONARR_PROD_API_KEY': 'prod-key',
+            'SONARR_DEV_URL': 'http://dev:8989',
+            'SONARR_DEV_API_KEY': 'dev-key',
+        }, clear=True):
+            env_config = parse_env_config()
+            aliases = env_config['sonarr']['_aliases']
+            assert aliases['prod'] == {'url': 'http://prod:8989', 'api_key': 'prod-key'}
+            assert aliases['dev'] == {'url': 'http://dev:8989', 'api_key': 'dev-key'}
+
+    def test_single_instance_no_aliases(self):
+        """SONARR_URL (no alias) returns single-instance config."""
+        from scraparr.parser import parse_env_config
+        with patch.dict(os.environ, {
+            'SONARR_URL': 'http://sonarr:8989',
+            'SONARR_API_KEY': 'key',
+        }, clear=True):
+            env_config = parse_env_config()
+            assert env_config['sonarr'] == {'url': 'http://sonarr:8989', 'api_key': 'key'}
+            assert '_aliases' not in env_config['sonarr']
+
+    def test_alias_takes_precedence_over_single(self):
+        """If any alias vars exist, use multi-instance mode."""
+        from scraparr.parser import parse_env_config
+        with patch.dict(os.environ, {
+            'SONARR_URL': 'http://single:8989',  # Ignored
+            'SONARR_PROD_URL': 'http://prod:8989',
+            'SONARR_PROD_API_KEY': 'prod-key',
+        }, clear=True):
+            env_config = parse_env_config()
+            assert '_aliases' in env_config['sonarr']
+
+    def test_merge_aliases_with_yaml_list(self):
+        """Merge env aliases into YAML list by matching alias field."""
+        yaml_config = {
+            'sonarr': [
+                {'url': 'http://yaml-prod:8989', 'api_key': 'yaml-key', 'alias': 'prod'},
+                {'url': 'http://yaml-dev:8989', 'api_key': 'dev-key', 'alias': 'dev'},
+            ]
+        }
+        env_config = {'sonarr': {'_aliases': {'prod': {'url': 'http://env-prod:8989'}}}}
+        result = deep_merge(yaml_config, env_config)
+
+        assert isinstance(result['sonarr'], list)
+        prod = next(s for s in result['sonarr'] if s.get('alias') == 'prod')
+        assert prod['url'] == 'http://env-prod:8989'
+        assert prod['api_key'] == 'yaml-key'
+
+    def test_env_adds_new_alias_to_yaml_list(self):
+        """Env can add new instance to YAML list via new alias."""
+        yaml_config = {'sonarr': [{'url': 'http://prod:8989', 'alias': 'prod'}]}
+        env_config = {'sonarr': {'_aliases': {'staging': {'url': 'http://staging:8989'}}}}
+        result = deep_merge(yaml_config, env_config)
+
+        assert len(result['sonarr']) == 2
+        aliases = [s['alias'] for s in result['sonarr']]
+        assert 'prod' in aliases and 'staging' in aliases
+
+    def test_env_only_multi_instance(self):
+        """Multi-instance config works with env only (no YAML)."""
+        env_config = {'sonarr': {'_aliases': {
+            'prod': {'url': 'http://prod:8989'},
+            'dev': {'url': 'http://dev:8989'},
+        }}}
+        result = deep_merge({}, env_config)
+        assert isinstance(result['sonarr'], list)
+        assert len(result['sonarr']) == 2

--- a/tests/test_config_env_substitution.py
+++ b/tests/test_config_env_substitution.py
@@ -333,3 +333,62 @@ class TestMultiInstanceAliasEnvVars:
         result = deep_merge({}, env_config)
         assert isinstance(result['sonarr'], list)
         assert len(result['sonarr']) == 2
+
+
+class TestServiceConfigValidation:
+    """Test post-merge validation of required fields."""
+
+    def test_valid_config_no_errors(self):
+        """Complete config with url and api_key returns no errors."""
+        from scraparr.config_loader import validate_service_config
+        config = {'url': 'http://sonarr:8989', 'api_key': 'test-key'}
+        errors = validate_service_config('sonarr', config)
+        assert errors == []
+
+    def test_missing_url_returns_error(self):
+        """Config missing url returns error."""
+        from scraparr.config_loader import validate_service_config
+        config = {'api_key': 'test-key'}
+        errors = validate_service_config('sonarr', config)
+        assert len(errors) == 1
+        assert "missing 'url'" in errors[0]
+
+    def test_missing_api_key_returns_error(self):
+        """Config missing api_key returns error."""
+        from scraparr.config_loader import validate_service_config
+        config = {'url': 'http://sonarr:8989'}
+        errors = validate_service_config('sonarr', config)
+        assert len(errors) == 1
+        assert "missing 'api_key'" in errors[0]
+
+    def test_missing_both_returns_two_errors(self):
+        """Config missing both url and api_key returns two errors."""
+        from scraparr.config_loader import validate_service_config
+        config = {'alias': 'test'}
+        errors = validate_service_config('sonarr', config)
+        assert len(errors) == 2
+
+    def test_none_config_returns_no_errors(self):
+        """None config (service not configured) returns no errors."""
+        from scraparr.config_loader import validate_service_config
+        errors = validate_service_config('sonarr', None)
+        assert errors == []
+
+    def test_multi_instance_list_validates_each(self):
+        """Multi-instance config (list) validates each instance."""
+        from scraparr.config_loader import validate_service_config
+        config = [
+            {'url': 'http://prod:8989', 'api_key': 'key1', 'alias': 'prod'},
+            {'url': 'http://dev:8989', 'alias': 'dev'},  # missing api_key
+        ]
+        errors = validate_service_config('sonarr', config)
+        assert len(errors) == 1
+        assert 'dev' in errors[0]
+        assert "missing 'api_key'" in errors[0]
+
+    def test_error_includes_alias(self):
+        """Error message includes the alias for identification."""
+        from scraparr.config_loader import validate_service_config
+        config = {'alias': 'production', 'url': 'http://sonarr:8989'}
+        errors = validate_service_config('sonarr', config)
+        assert 'production' in errors[0]


### PR DESCRIPTION
## Summary

Always load both YAML and env vars, with env vars taking priority.

**Before:** Env vars only used when YAML file is missing  
**After:** Both always loaded, env vars override YAML values

## Background: Fixing PR #154

PR #154 added `${VAR}` substitution inside YAML files, but had two issues:

1. **Either/or behavior remained**: Environment variables like `SONARR_URL` were still only parsed when the YAML file was missing entirely. Users couldn't override a single field via env var.

2. **Type coercion bug**: `${VAR:-30}` for an `interval` field returned string `"30"` instead of int `30`, causing type mismatches.

This PR fixes both by:
- Always loading both sources and merging (env wins)
- Adding `coerce_config_types()` that runs after merge to convert strings to int/bool based on field name

## Changes

### New Features
- **Partial override**: Set `SONARR_URL` alone to override just the URL while keeping `api_key` and other settings from YAML
- **Multi-instance aliases**: Use `SONARR_PROD_URL`, `SONARR_DEV_API_KEY` to override specific instances by matching the `alias` field
- **Add services via env**: Add `RADARR_URL` + `RADARR_API_KEY` to configure a new service without touching YAML
- **GENERAL_* and AUTH_* support**: Override `general.port`, `auth.username`, etc. via env vars
- **.env file support**: Loads `.env` via `load_dotenv()` so values are available for both `${VAR}` substitution in YAML and as env var overrides

### Bug Fixes
- **Boolean parsing**: `SONARR_DETAILED=false` now correctly returns `False` (was truthy string `"false"`)
- **Type coercion for ${VAR}**: `${INTERVAL:-30}` now returns int `30` instead of string `"30"`
- **Invalid config error handling**: `GENERAL_PORT=abc` now shows clean error message instead of traceback
- **Missing field validation**: Configs missing `url` or `api_key` now show clear error messages instead of crashing at runtime

## Examples

### Partial Override
```bash
# config.yaml has url + api_key + interval
docker run -e SONARR_URL=http://different:8989 ...
# Result: URL from env, api_key and interval from YAML
```

### Multi-Instance Aliases
```yaml
# config.yaml
sonarr:
  - url: http://prod:8989
    api_key: prod-key
    alias: prod
  - url: http://dev:8989
    api_key: dev-key  
    alias: dev
```
```bash
docker run -e SONARR_PROD_URL=http://new-prod:8989 ...
# Result: prod URL overridden, dev unchanged
```

### .env File (Local Development)
```bash
# .env
SONARR_API_KEY=my-secret-key
```
```yaml
# config.yaml - can reference .env values!
sonarr:
  url: http://localhost:8989
  api_key: ${SONARR_API_KEY}
```

## Supported Variables

| Section | Pattern |
|---------|---------|
| Services | `{SERVICE}_URL`, `{SERVICE}_API_KEY`, `{SERVICE}_ALIAS`, `{SERVICE}_API_VERSION`, `{SERVICE}_INTERVAL`, `{SERVICE}_DETAILED`, `{SERVICE}_WITHIN`, `{SERVICE}_EPISODE_QUALITY_STATS` |
| Multi-Instance | `{SERVICE}_{ALIAS}_URL`, `{SERVICE}_{ALIAS}_API_KEY`, etc. |
| General | `GENERAL_PORT`, `GENERAL_ADDRESS`, `GENERAL_WORKERS`, `GENERAL_LOG_LEVEL`, `GENERAL_PATH` |
| Auth | `AUTH_USERNAME`, `AUTH_PASSWORD`, `AUTH_TOKEN` |

Closes #156

---
Generated with [Claude Code](https://claude.ai/code)