### PR TITLE
handle empty data for users, requests, and issues

### DIFF
--- a/src/scraparr/connectors/seerr.py
+++ b/src/scraparr/connectors/seerr.py
@@ -35,6 +35,8 @@ class Seerr(ConnectorModule):
         self.metrics.LAST_SCRAPE.labels(self.alias).set(end_time)
         self.metrics.SCRAPE_DURATION.labels(self.alias).set(end_time - initial_time)
 
+        print(users, requests, issues)
+
         if users is None or requests is None or issues is None:
             return {}
 
@@ -186,7 +188,7 @@ class Seerr(ConnectorModule):
             return None
         UP.labels(self.alias, self.service).set(1)
         if not res["results"]:
-            return None
+            return res["results"]
 
         # Fetch all titles in parallel (only when detailed=True)
         if self.detailed:

--- a/src/scraparr/connectors/seerr.py
+++ b/src/scraparr/connectors/seerr.py
@@ -35,8 +35,6 @@ class Seerr(ConnectorModule):
         self.metrics.LAST_SCRAPE.labels(self.alias).set(end_time)
         self.metrics.SCRAPE_DURATION.labels(self.alias).set(end_time - initial_time)
 
-        print(users, requests, issues)
-
         if users is None or requests is None or issues is None:
             return {}
 

--- a/src/scraparr/connectors/seerr.py
+++ b/src/scraparr/connectors/seerr.py
@@ -35,7 +35,7 @@ class Seerr(ConnectorModule):
         self.metrics.LAST_SCRAPE.labels(self.alias).set(end_time)
         self.metrics.SCRAPE_DURATION.labels(self.alias).set(end_time - initial_time)
 
-        if not users or not requests or not issues:
+        if users is None or requests is None or issues is None:
             return {}
 
         return {"users": users, "requests": requests, "issues": issues}
@@ -49,7 +49,7 @@ class Seerr(ConnectorModule):
 
         if not res or "results" not in res:
             UP.labels(self.alias, self.service).set(0)
-            return []
+            return None
 
         UP.labels(self.alias, self.service).set(1)
 
@@ -123,10 +123,10 @@ class Seerr(ConnectorModule):
 
         if not res or "results" not in res:
             UP.labels(self.alias, self.service).set(0)
-            return []
+            return None
         UP.labels(self.alias, self.service).set(1)
         if not res["results"]:
-            return []
+            return None
 
         # Fetch all titles in parallel (only when detailed=True)
         if self.detailed:
@@ -183,10 +183,10 @@ class Seerr(ConnectorModule):
 
         if not res or "results" not in res:
             UP.labels(self.alias, self.service).set(0)
-            return []
+            return None
         UP.labels(self.alias, self.service).set(1)
         if not res["results"]:
-            return []
+            return None
 
         # Fetch all titles in parallel (only when detailed=True)
         if self.detailed:


### PR DESCRIPTION
This pull request modifies how the Seerr connector handles empty or missing data responses from its API calls. Instead of returning empty lists, the methods now return `None` when no results are found, which helps distinguish between "no data" and "empty data" scenarios. The main changes are grouped below by theme.

Handling empty/missing data responses:

* Updated `get_users`, `get_requests`, and `get_issues` methods to return `None` instead of empty lists when the API response is missing or contains no results. [[1]](diffhunk://#diff-de52a92ee931b576c9bae40bce005d274c4fe8f92cd9569aaf45ecf369c470b1L52-R52) [[2]](diffhunk://#diff-de52a92ee931b576c9bae40bce005d274c4fe8f92cd9569aaf45ecf369c470b1L126-R129) [[3]](diffhunk://#diff-de52a92ee931b576c9bae40bce005d274c4fe8f92cd9569aaf45ecf369c470b1L186-R189)
* Modified the `scrape` method to check for `None` values for users, requests, and issues, and return an empty dictionary if any are missing.


Closes #164 