### PR TITLE
fix: add uv.lock to workflow trigger

### DIFF
--- a/.github/workflows/main-image.yml
+++ b/.github/workflows/main-image.yml
@@ -9,6 +9,8 @@ on:
     paths:
       - 'src/**'
       - 'Dockerfile'
+      - 'uv.lock'
+      - 'pyproject.toml'
   workflow_dispatch:
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.

--- a/.github/workflows/publish-pr-image.yaml
+++ b/.github/workflows/publish-pr-image.yaml
@@ -7,6 +7,8 @@ on:
     paths:
       - 'src/**'
       - 'Dockerfile'
+      - 'uv.lock'
+      - 'pyproject.toml'
   workflow_dispatch:
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - '**.py'
+      - 'uv.lock'
+      - 'pyproject.toml'
       - '**/requirements.txt'
   workflow_dispatch:
 

--- a/.github/workflows/remove-pr-image.yml
+++ b/.github/workflows/remove-pr-image.yml
@@ -8,6 +8,8 @@ on:
     paths:
       - 'src/**'
       - 'Dockerfile'
+      - 'uv.lock'
+      - 'pyproject.toml'
   workflow_dispatch:
 
 # Defines two custom environment variables for the workflow. These are used for the Container registry domain, and a name for the Docker image that this workflow builds.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - '**.py'
+      - 'uv.lock'
       - 'pyproject.toml'
       - '**/requirements.txt'
       - 'tests/**'


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow triggers to ensure that changes to dependency and configuration files properly trigger relevant workflows. Specifically, it adds `uv.lock` and `pyproject.toml` to the list of files that, when modified, will trigger the build, test, lint, and image-related workflows.

Workflow trigger improvements:

* Added `uv.lock` and `pyproject.toml` to the `paths` list in `.github/workflows/main-image.yml`, `.github/workflows/publish-pr-image.yaml`, and `.github/workflows/remove-pr-image.yml` so that changes to these files will trigger the corresponding image build and removal workflows. [[1]](diffhunk://#diff-92e1b943668296f809f801b228f9b341bc5a53e51ac0158d90509dcffd6e49bfR12-R13) [[2]](diffhunk://#diff-40fe26753a088fb436cb5e0d9f10270d8cc4a481742844039df9a600c93d728dR10-R11) [[3]](diffhunk://#diff-09a635e2bb115a94d963821a485e2679f076c76c96e8b0a9d6edff43fb42c3c7R11-R12)
* Updated `.github/workflows/pylint.yml` and `.github/workflows/test.yml` to include `uv.lock` (and in the case of `pylint.yml`, also `pyproject.toml`) in the trigger paths, ensuring that dependency or configuration changes will run linting and test jobs as appropriate. [[1]](diffhunk://#diff-3fb2867e4a7c0ecbfdf0f36a3078f1689dca17453c5e0ebdd0671bb94733b5a3R7-R8) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R7)