### PR TITLE
Fix(workflow): add test and linting to img build

### DIFF
--- a/.github/workflows/main-image.yml
+++ b/.github/workflows/main-image.yml
@@ -15,8 +15,11 @@ jobs:
   lint:
     uses: ./.github/workflows/lint.yml
 
+  test:
+    uses: ./.github/workflows/test.yml
+
   build-and-push-image:
-    needs: lint
+    needs: [lint, test]
     uses: ./.github/workflows/docker-build.yml
     with:
       registry_image: ghcr.io/${{ github.repository }}

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -5,7 +5,14 @@ on:
     types: [released]
 
 jobs:
+  lint:
+    uses: ./.github/workflows/lint.yml
+
+  test:
+    uses: ./.github/workflows/test.yml
+
   build-and-push-image:
+    needs: [lint, test]
     uses: ./.github/workflows/docker-build.yml
     with:
       registry_image: ghcr.io/${{ github.repository }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
       - '**/requirements.txt'
       - 'tests/**'
   workflow_dispatch:
+  workflow_call:
 
 permissions:
   contents: read


### PR DESCRIPTION
This pull request updates the CI workflow configuration to improve quality control and ensure that both linting and testing are completed before building and publishing Docker images. The main changes involve updating workflow dependencies and enabling workflow reusability.

**Workflow dependency improvements:**

* The `build-and-push-image` job in both `.github/workflows/main-image.yml` and `.github/workflows/publish-image.yml` now depends on both the `lint` and `test` jobs, ensuring images are only built after successful linting and testing. [[1]](diffhunk://#diff-92e1b943668296f809f801b228f9b341bc5a53e51ac0158d90509dcffd6e49bfR18-R22) [[2]](diffhunk://#diff-20a6c39db0bdbf998cfc2078fa28cc6734ee3dd8efd0a7edab29379b6ed95aa8R8-R15)
* Added `test` and `lint` jobs to `.github/workflows/publish-image.yml` to ensure code quality checks are performed before publishing.

**Workflow reusability:**

* Added the `workflow_call` trigger to `.github/workflows/test.yml`, allowing this workflow to be called from other workflows for better modularity and reuse.