### PR TITLE
Switch to uv for dependency management in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,13 @@
-FROM python:3.14-alpine
+FROM ghcr.io/astral-sh/uv:python3.14-alpine
 
-# Copy the current directory contents into the container at /app
-COPY src /
+WORKDIR /app
 
-# Set the working directory
-WORKDIR /scraparr
+COPY pyproject.toml uv.lock ./
+COPY src/ src/
 
-# Install any needed packages specified in requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt
+RUN uv sync --frozen --no-dev
 
 # Make port 7100 available to the world outside this container
 EXPOSE 7100
 
-WORKDIR /
-
-# Define Entry point
-ENTRYPOINT ["python", "-um", "scraparr.scraparr"]
+ENTRYPOINT ["uv", "run", "--no-sync", "python", "-um", "scraparr.scraparr"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,32 @@
-FROM ghcr.io/astral-sh/uv:python3.14-alpine
+FROM ghcr.io/astral-sh/uv:python3.14-alpine AS builder
+
+ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy UV_NO_DEV=1 UV_PYTHON_DOWNLOADS=0
 
 WORKDIR /app
 
-COPY pyproject.toml uv.lock ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    --mount=type=bind,source=README.md,target=README.md \
+    --mount=type=bind,source=src/scraparr/requirements.txt,target=src/scraparr/requirements.txt \
+    uv sync --locked --no-install-project
+
 COPY src/ src/
 
-RUN uv sync --frozen --no-dev
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --locked
 
-# Make port 7100 available to the world outside this container
+
+FROM python:3.14-alpine
+
+COPY --from=builder /app /app
+
+ENV PATH="/app/.venv/bin:$PATH"
+
+WORKDIR /app
+
 EXPOSE 7100
 
-ENTRYPOINT ["uv", "run", "--no-sync", "python", "-um", "scraparr.scraparr"]
+ENTRYPOINT ["python", "-um", "scraparr.scraparr"]

--- a/Dockerfile-pylint
+++ b/Dockerfile-pylint
@@ -1,14 +1,10 @@
-FROM python:3.14-alpine
+FROM ghcr.io/astral-sh/uv:python3.14-alpine
 
-# Copy the current directory contents into the container at /app
-COPY src /
+WORKDIR /app
 
-# Set the working directory
-WORKDIR /scraparr
+COPY pyproject.toml uv.lock ./
+COPY src/ src/
 
-# Install any needed packages specified in requirements.txt
-RUN pip install --no-cache-dir -r requirements.txt
+RUN uv sync --frozen
 
-RUN pip install pylint
-
-ENTRYPOINT ["pylint", "--recursive=y", "/scraparr"]
+ENTRYPOINT ["uv", "run", "--no-sync", "pylint", "--recursive=y", "src/scraparr"]

--- a/Dockerfile-pylint
+++ b/Dockerfile-pylint
@@ -1,10 +1,30 @@
-FROM ghcr.io/astral-sh/uv:python3.14-alpine
+FROM ghcr.io/astral-sh/uv:python3.14-alpine AS builder
+
+ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy UV_PYTHON_DOWNLOADS=0
 
 WORKDIR /app
 
-COPY pyproject.toml uv.lock ./
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    --mount=type=bind,source=README.md,target=README.md \
+    --mount=type=bind,source=src/scraparr/requirements.txt,target=src/scraparr/requirements.txt \
+    uv sync --locked --no-install-project
+
 COPY src/ src/
 
-RUN uv sync --frozen
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --locked
 
-ENTRYPOINT ["uv", "run", "--no-sync", "pylint", "--recursive=y", "src/scraparr"]
+
+FROM python:3.14-alpine
+
+COPY --from=builder /app /app
+
+ENV PATH="/app/.venv/bin:$PATH"
+
+WORKDIR /app
+
+ENTRYPOINT ["pylint", "--recursive=y", "src/scraparr"]

--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -6,8 +6,8 @@ services:
     ports:
       - "7100:7100"
     volumes:
-      - ./src/scraparr:/scraparr
-      - ./config.secret.yaml:/scraparr/config/config.yaml
+      - ./src/scraparr:/app/src/scraparr
+      - ./config.secret.yaml:/app/src/scraparr/config/config.yaml
     #env_file:
     #  - ./dev.secret.env
   scraparr1:
@@ -23,4 +23,4 @@ services:
     #    context: .
     #    dockerfile: Dockerfile-pylint
     volumes:
-      - ./src/scraparr:/scraparr
+      - ./src/scraparr:/app/src/scraparr

--- a/compose.yaml
+++ b/compose.yaml
@@ -5,4 +5,4 @@ services:
     ports:
       - "7100:7100"
     volumes:
-      - ./config.yaml:/scraparr/config/config.yaml # For v1 Release use /scraparr/config.cnf and an ini File
+      - ./config.yaml:/app/src/scraparr/config/config.yaml

--- a/src/scraparr/scraparr.py
+++ b/src/scraparr/scraparr.py
@@ -9,6 +9,7 @@ Contributors: TheGameProfi
 License: GPL-3.0
 """
 
+import os
 import sys
 import threading
 import logging
@@ -35,7 +36,18 @@ logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(
 # This allows ${VAR} in YAML to reference .env values
 load_dotenv()
 
-CONFIG_FILE_LOCATION = "/scraparr/config/config.yaml"
+_CONFIG_PATHS = [
+    "/app/src/scraparr/config/config.yaml",
+    "/scraparr/config/config.yaml",
+]
+
+CONFIG_FILE_LOCATION = next((p for p in _CONFIG_PATHS if os.path.exists(p)), _CONFIG_PATHS[0])
+
+if CONFIG_FILE_LOCATION == _CONFIG_PATHS[1]:
+    logging.warning(
+        "Config at '%s' is deprecated. Please move your config to '%s'.",
+        _CONFIG_PATHS[1], _CONFIG_PATHS[0]
+    )
 
 config_file = None
 


### PR DESCRIPTION
This pull request modernizes the Docker build process, updates configuration paths, and improves development workflows. The main changes include switching to the `uv` Python package manager for faster and more reproducible builds, updating configuration file paths to a new location under `/app`, and ensuring backward compatibility with warnings for deprecated paths. Docker and Compose files are updated to match these changes.

**Docker build and dependency management improvements:**

* Switched Dockerfiles (`Dockerfile`, `Dockerfile-pylint`) to use `ghcr.io/astral-sh/uv:python3.14-alpine` as a builder and to manage dependencies with `uv` for faster, more reproducible builds. The application is now installed in `/app` and uses a virtual environment. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-L17) [[2]](diffhunk://#diff-f90312a0c61f87ea99689d7ab045942d13dadba12fbfc23b678cb005b3030981L1-R30)
* Updated `ENTRYPOINT` in `Dockerfile-pylint` to run `pylint` on `src/scraparr` instead of `/scraparr`.

**Configuration path updates and compatibility:**

* Changed the default config file location in `src/scraparr/scraparr.py` to `/app/src/scraparr/config/config.yaml`, with a fallback to `/scraparr/config/config.yaml` and a warning if the deprecated path is used.
* Updated Compose files (`compose.yaml`, `compose-dev.yaml`) to mount config files and source code to the new `/app`-based paths. [[1]](diffhunk://#diff-facaded51b7d1c9656ae43b449b69aa398fee9129321a0001d97048c00c8cc1cL8-R8) [[2]](diffhunk://#diff-89471ffb96d84b413db21e0424cb0c60ee566b73230e705808be6ca5c5f4d315L9-R10) [[3]](diffhunk://#diff-89471ffb96d84b413db21e0424cb0c60ee566b73230e705808be6ca5c5f4d315L26-R26)

**Other improvements:**

* Added `import os` to `scraparr.py` to support the new config path logic.

Closes #160 