### PR TITLE
ci: gate PR image build/push and comment behind pr-image environment

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -32,6 +32,11 @@ on:
         required: false
         type: boolean
         default: false
+      environment:
+        description: 'GitHub environment to run the build job under (for protection rules)'
+        required: false
+        type: string
+        default: ''
     secrets:
       DOCKERHUB_TOKEN:
         required: false
@@ -43,6 +48,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/publish-pr-image.yaml
+++ b/.github/workflows/publish-pr-image.yaml
@@ -22,11 +22,13 @@ jobs:
     with:
       registry_image: ghcr.io/thecfu/scraparr-dev
       tags: type=raw,value=pr${{ github.event.pull_request.number }}
+      environment: pr-image
     secrets: inherit
 
   comment:
     needs: build-and-push-image
     runs-on: ubuntu-latest
+    environment: pr-image
     steps:
       - name: Comment PR image availability
         uses: marocchino/sticky-pull-request-comment@v2


### PR DESCRIPTION
Fork PRs get a read-only GITHUB_TOKEN and no secrets by default, which breaks both the ghcr.io push and the sticky PR comment. Requiring approval via the pr-image environment lifts that restriction once a maintainer approves the run.